### PR TITLE
✨ feat: Feign 을 이용한 자동 전송 기능 + DB 저장 및 이벤트 발행 로직 구현 #4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,8 +43,8 @@ jobs:
             ${{ runner.os }}-gradle-
 
       # 임시 설정 -> 추후 ConfigMap 활용 예정
-      # - name: create application.yml
-      #  run: echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
+      - name: create application.yml
+        run: echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
 
       # Gradle 빌드 실행 + 테스트를 포함
       - name: Build with Gradle

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,9 @@ jobs:
       - name: create application.yml
         run: echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
 
+      - name: create application-test.yml
+        run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
+
       # Gradle 빌드 실행 + 테스트를 포함
       - name: Build with Gradle
         run: ./gradlew clean build --no-daemon -Djava.net.preferIPv4Stack=true -Dspring.profiles.active=ci

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
         run: echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
 
       - name: create application-test.yml
-        run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" | base64 --decode > src/main/resources/application.yml
+        run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" | base64 --decode > src/main/resources/application-test.yml
 
       # Gradle 빌드 실행 + 테스트를 포함
       - name: Build with Gradle

--- a/src/main/java/com/grow/notification_service/notification/application/NotificationService.java
+++ b/src/main/java/com/grow/notification_service/notification/application/NotificationService.java
@@ -1,0 +1,7 @@
+package com.grow.notification_service.notification.application;
+
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+
+public interface NotificationService {
+    void processNotification(NotificationRequestDto requestDto);
+}

--- a/src/main/java/com/grow/notification_service/notification/application/NotificationServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/notification/application/NotificationServiceImpl.java
@@ -1,0 +1,87 @@
+package com.grow.notification_service.notification.application;
+
+import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
+import com.grow.notification_service.notification.domain.model.Notification;
+import com.grow.notification_service.notification.domain.repository.NotificationRepository;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+/**
+ * <h2>알림 서비스의 구현 클래스</h2>
+ * 알림 요청을 받아 데이터베이스에 저장하고, 저장 후 이벤트를 발행하여
+ * 실시간 알림(예: SSE 푸시)을 트리거하는 역할을 합니다.
+ *
+ * <p>이 클래스는 @Async를 사용하여 비동기적으로 동작하며, @Transactional로
+ * 데이터베이스 작업의 일관성을 보장합니다. ApplicationEventPublisher를 통해
+ * NotificationSavedEvent를 발행하여 다른 서비스(SSE 알림 전송)와 연계됩니다.
+ *
+ * <p><b>주요 기능:</b>
+ * <ul>
+ *     <li>알림 DTO를 엔티티로 변환하여 DB 저장</li>
+ *     <li>저장 후 이벤트 발행으로 알림 푸시 트리거</li>
+ *     <li>로그 기록을 통한 작업 추적</li>
+ * </ul>
+ *
+ * @since 25.07.30
+ * @version 1.0.0
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher publisher; // 이벤트 발행
+
+    /**
+     * 알림을 처리하는 엔트리 포인트입니다. DB 저장 후 이벤트를 발행합니다.
+     * 이 메서드는 비동기(@Async)로 실행되며, 트랜잭션(@Transactional) 내에서 동작합니다.
+     *
+     * <p>처리 순서:
+     * <ol>
+     *     <li>saveNotification 메서드를 호출하여 알림을 DB에 저장합니다.</li>
+     *     <li>NotificationSavedEvent를 발행하여 다른 컴포넌트(예: SSE 서비스)에서 알림을 처리할 수 있도록 합니다.</li>
+     *     <li>INFO 레벨 로그를 기록합니다.</li>
+     * </ol>
+     *
+     * @param request 알림 요청 DTO. memberId, content, notificationType 등의 필드를 포함해야 합니다.
+     */
+    @Async
+    @Override
+    @Transactional
+    public void processNotification(NotificationRequestDto request) {
+        // 1. DB에 알림 저장
+        saveNotification(request);
+        // 2. 푸시 알림 전송 이벤트 발행
+        publisher.publishEvent(new NotificationSavedEvent(this, request)); // SSE 트리거 이벤트 발행
+        log.info("[Matching Notification] 매칭 알림 이벤트 발행 완료 - memberId: {}, content: {}",
+                request.getMemberId(), request.getContent());
+    }
+
+    /**
+     * 알림 요청 DTO를 Notification 엔티티로 변환하여 데이터베이스에 저장합니다.
+     * 저장 후 INFO 레벨 로그를 기록합니다.
+     *
+     * <p>이 메서드는 processNotification 내에서 호출되며, Clock.systemDefaultZone()을
+     * 사용하여 현재 시간을 알림 생성 시점으로 설정합니다.
+     *
+     * @param request 알림 요청 DTO. 저장에 필요한 필드를 포함합니다.
+     */
+    private void saveNotification(NotificationRequestDto request) {
+        notificationRepository.save(
+                Notification.create(
+                        request.getMemberId(),
+                        request.getContent(),
+                        Clock.systemDefaultZone(),
+                        request.getNotificationType()
+                ));
+        log.info("[Matching Notification] 매칭 알림 저장 완료 - memberId: {}, content: {}",
+                request.getMemberId(), request.getContent());
+    }
+}

--- a/src/main/java/com/grow/notification_service/notification/application/event/NotificationSavedEvent.java
+++ b/src/main/java/com/grow/notification_service/notification/application/event/NotificationSavedEvent.java
@@ -1,0 +1,28 @@
+package com.grow.notification_service.notification.application.event;
+
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * <h2>알림 저장 후 발행되는 커스텀 이벤트 클래스</h2>
+ * Spring의 ApplicationEvent를 상속받아 NotificationRequestDto를 포함하며,
+ * 이벤트 리스너에서 이를 수신하여 후속 처리(SSE 알림 전송)를 수행합니다.
+ *
+ * <p>@Getter를 사용하여 dto 필드에 대한 getter 메서드를 제공합니다.
+ * 이 이벤트는 NotificationServiceImpl의 processNotification 메서드에서 발행됩니다.
+ *
+ * <p><b>주요 용도:</b> 알림 DB 저장 후 실시간 푸시 알림을 트리거하기 위한 이벤트.
+ *
+ * <p><b>주의:</b> source는 이벤트 발행 객체(예: 서비스 인스턴스)를 나타내며,
+ * dto는 null이 아닌 유효한 NotificationRequestDto 인스턴스여야 합니다.
+ */
+@Getter
+public class NotificationSavedEvent extends ApplicationEvent {
+    private final NotificationRequestDto dto;
+
+    public NotificationSavedEvent(Object source, NotificationRequestDto dto) {
+        super(source);
+        this.dto = dto;
+    }
+}

--- a/src/main/java/com/grow/notification_service/notification/application/sse/SseNotificationService.java
+++ b/src/main/java/com/grow/notification_service/notification/application/sse/SseNotificationService.java
@@ -1,5 +1,6 @@
 package com.grow.notification_service.notification.application.sse;
 
+import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -8,4 +9,5 @@ public interface SseNotificationService {
     void sendNotification(Long memberId,
                           NotificationType notificationType,
                           String message);
+    void sendNotification(NotificationSavedEvent event);
 }

--- a/src/main/java/com/grow/notification_service/notification/application/sse/SseNotificationServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/notification/application/sse/SseNotificationServiceImpl.java
@@ -1,9 +1,13 @@
 package com.grow.notification_service.notification.application.sse;
 
+import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
 import com.grow.notification_service.notification.application.exception.SseException;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -109,5 +113,27 @@ public class SseNotificationServiceImpl implements SseNotificationService {
 
         log.warn("[Matching Notification] SSE 연결 실패 - memberId: {}", memberId);
         throw new SseException(SSE_NOT_CONNECTED);
+    }
+
+    /**
+     * 이벤트 리스너: SSE로 알림 전송 (비동기)
+     * NotificationSavedEvent를 수신하여 이벤트에 포함된 DTO를 추출한 후,
+     * sendNotification 메서드를 호출하여 SSE 알림을 전송합니다.
+     *
+     * <p>이 메서드는 @Async로 비동기 처리되며, @EventListener로 이벤트를 리스닝합니다.
+     *
+     * @param event 저장된 알림 이벤트 (NotificationSavedEvent). dto를 포함합니다.
+     */
+    @Async
+    @Override
+    @EventListener
+    public void sendNotification(NotificationSavedEvent event) {
+        NotificationRequestDto dto = event.getDto();
+
+        sendNotification(
+                dto.getMemberId(),
+                dto.getNotificationType(),
+                dto.getContent()
+        );
     }
 }

--- a/src/main/java/com/grow/notification_service/notification/application/sse/SseSendService.java
+++ b/src/main/java/com/grow/notification_service/notification/application/sse/SseSendService.java
@@ -2,12 +2,14 @@ package com.grow.notification_service.notification.application.sse;
 
 import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-public interface SseNotificationService {
+public interface SseSendService {
     SseEmitter subscribe(Long memberId);
     void sendNotification(Long memberId,
                           NotificationType notificationType,
                           String message);
-    void sendNotification(NotificationSavedEvent event);
+    void handleNotificationSavedEvent(NotificationSavedEvent event);
 }

--- a/src/main/java/com/grow/notification_service/notification/application/sse/SseSendServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/notification/application/sse/SseSendServiceImpl.java
@@ -9,6 +9,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -43,7 +45,7 @@ import static com.grow.notification_service.notification.application.exception.E
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SseNotificationServiceImpl implements SseNotificationService {
+public class SseSendServiceImpl implements SseSendService {
 
     private final Map<Long, SseEmitter> sseEmitters = new ConcurrentHashMap<>();
 
@@ -126,8 +128,8 @@ public class SseNotificationServiceImpl implements SseNotificationService {
      */
     @Async
     @Override
-    @EventListener
-    public void sendNotification(NotificationSavedEvent event) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotificationSavedEvent(NotificationSavedEvent event) {
         NotificationRequestDto dto = event.getDto();
 
         sendNotification(

--- a/src/main/java/com/grow/notification_service/notification/presentation/controller/NotificationController.java
+++ b/src/main/java/com/grow/notification_service/notification/presentation/controller/NotificationController.java
@@ -1,7 +1,7 @@
 package com.grow.notification_service.notification.presentation.controller;
 
 import com.grow.notification_service.notification.application.NotificationService;
-import com.grow.notification_service.notification.application.sse.SseNotificationService;
+import com.grow.notification_service.notification.application.sse.SseSendService;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
 import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
 import com.grow.notification_service.notification.presentation.dto.rsdata.RsData;
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationController {
 
     private final NotificationService notificationService;
-    private final SseNotificationService sseNotificationService;
+    private final SseSendService sseSendService;
 
     /**
      * SSE (Server-Sent Events) 연결을 위한 구독 엔드포인트입니다.
@@ -40,7 +40,7 @@ public class NotificationController {
             produces = MediaType.TEXT_EVENT_STREAM_VALUE
     )
     public SseEmitter subscribe(@RequestHeader("X-Authorization-Id") Long memberId) {
-        return sseNotificationService.subscribe(memberId);
+        return sseSendService.subscribe(memberId);
     }
 
     @PostMapping("/api/v1/notify")
@@ -49,7 +49,7 @@ public class NotificationController {
                                               @RequestBody String message) {
 
         // sendNotification 메서드 호출
-        sseNotificationService.sendNotification(memberId, notificationType, message);
+        sseSendService.sendNotification(memberId, notificationType, message);
 
         return new RsData<>(
                 "200",

--- a/src/main/java/com/grow/notification_service/notification/presentation/dto/NotificationRequestDto.java
+++ b/src/main/java/com/grow/notification_service/notification/presentation/dto/NotificationRequestDto.java
@@ -1,0 +1,48 @@
+
+package com.grow.notification_service.notification.presentation.dto;
+
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 알림 전송을 위한 DTO 클래스.
+ * 이 DTO는 알림 요청 데이터를 캡슐화하며, 멤버 ID, 내용, 타입, 타임스탬프, 재시도 횟수를 포함합니다.
+ * 주로 NotificationServiceClient나 QueueService에서 사용되어 장애 시 재시도 로직을 지원합니다.
+ *
+ * <p>이 클래스는 Lombok의 @Getter와 @Builder를 사용하여 간편한 객체 생성과 접근을 제공합니다.
+ * retryCount 필드는 알림 전송 실패 시 증가되며, 재시도 한계를 관리할 수 있습니다.</p>
+ *
+ * @see LocalDateTime
+ */
+@Getter
+@Builder
+public class NotificationRequestDto {
+
+    /**
+     * 알림을 받을 멤버의 고유 ID.
+     */
+    @NotNull
+    private Long memberId;
+
+    /**
+     * 알림 내용 (텍스트 메시지).
+     */
+    @NotNull
+    private String content;
+
+    /**
+     * 알림 타입 (예: "MATCH_SUCCESS" 등).
+     */
+    @NotNull
+    private NotificationType notificationType;
+
+    /**
+     * 알림 생성 타임스탬프.
+     */
+    private LocalDateTime timestamp;
+}

--- a/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTest.java
@@ -1,0 +1,136 @@
+package com.grow.notification_service.notification.application;
+
+import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
+import com.grow.notification_service.notification.application.exception.SseException;
+import com.grow.notification_service.notification.application.sse.SseNotificationService;
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationJpaEntity;
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import com.grow.notification_service.notification.infra.persistence.repository.NotificationJpaRepository;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@RecordApplicationEvents // 이벤트 기록
+class NotificationServiceImplTest {
+
+    @Autowired
+    private NotificationServiceImpl notificationService;
+
+    @MockitoSpyBean
+    private SseNotificationService sseNotificationService;
+
+    @Autowired
+    private NotificationJpaRepository notificationJpaRepository;
+
+    @Autowired
+    private ApplicationEvents events;  // 기록된 이벤트 확인을 위한 객체
+
+    @Test
+    @DisplayName("DB에 알림 저장 후 NotificationSavedEvent가 정상적으로 발행되고 SSE 알림이 비동기적으로 전송되는지 확인")
+    void testEventPublishingAndSseSendingOnSave() {
+        // given: SSE 연결 설정 (emitter 생성 및 등록)
+        Long memberId = 1L;
+        sseNotificationService.subscribe(memberId);  // SSE 연결 구독
+
+        NotificationRequestDto request = NotificationRequestDto.builder()
+                .memberId(memberId)
+                .notificationType(NotificationType.MATCHING_SUCCESS)
+                .content("테스트 알림 내용")
+                .build();
+
+        // when: 알림 처리 (DB 저장 및 이벤트 발행)
+        notificationService.processNotification(request);
+
+        // then: DB에 저장되었는지 확인
+        List<NotificationJpaEntity> savedNotifications = notificationJpaRepository.findAll();
+        assertThat(savedNotifications).hasSize(1);
+        assertThat(savedNotifications.getFirst().getContent()).isEqualTo("테스트 알림 내용");
+
+        // 이벤트가 발행되었는지 확인 (기록된 이벤트 사용)
+        long eventCount = events.stream(NotificationSavedEvent.class).count();
+        assertThat(eventCount).isEqualTo(1);
+
+        // SSE 전송 메서드가 비동기적으로 호출되었는지 Spy로 확인 (ArgumentCaptor로 인자 검증)
+        ArgumentCaptor<Long> memberIdCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<NotificationType> typeCaptor = ArgumentCaptor.forClass(NotificationType.class);
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(sseNotificationService, timeout(5000).times(1))  // 비동기 대기
+                .sendNotification(memberIdCaptor.capture(), typeCaptor.capture(), messageCaptor.capture());
+
+        assertThat(memberIdCaptor.getValue()).isEqualTo(memberId);
+        assertThat(typeCaptor.getValue()).isEqualTo(NotificationType.MATCHING_SUCCESS);
+        assertThat(messageCaptor.getValue()).isEqualTo("테스트 알림 내용");
+    }
+
+    @Test
+    @DisplayName("SSE 연결(emitter)이 없을 때 이벤트 발행 시 SseException이 발생하고 알림 전송이 실패하는지 확인")
+    void testEventPublishingFailureWithoutEmitter() {
+        // given: SSE 연결 없음 (emitter 미등록)
+        Long memberId = 1L;
+        NotificationRequestDto request = NotificationRequestDto.builder()
+                .memberId(memberId)
+                .notificationType(NotificationType.MATCHING_SUCCESS)
+                .content("테스트 알림 내용")
+                .build();
+
+        // when & then: 알림 처리 시 예외 발생 확인
+        notificationService.processNotification(request);  // DB 저장은 성공하지만 SSE 전송에서 예외
+
+        // DB 저장은 성공
+        List<NotificationJpaEntity> savedNotifications = notificationJpaRepository.findAll();
+        assertThat(savedNotifications).hasSize(1);
+
+        // 이벤트는 발행되었으나 SSE 전송에서 예외 발생
+        assertThrows(SseException.class, () -> sseNotificationService.sendNotification(
+                1L,
+                NotificationType.MATCHING_SUCCESS,
+                "테스트 알림 내용")
+        );
+    }
+
+    @Test
+    @DisplayName("이벤트 처리 메서드가 비동기(@Async)로 동작하는지 확인 (스레드 이름 검증)")
+    void testAsyncEventHandling() {
+        // given: SSE 연결 설정
+        Long memberId = 1L;
+        sseNotificationService.subscribe(memberId);
+
+        NotificationRequestDto request = NotificationRequestDto.builder()
+                .memberId(memberId)
+                .notificationType(NotificationType.MATCHING_SUCCESS)
+                .content("테스트 알림 내용")
+                .build();
+
+        // Spy로 sendNotification 메서드의 스레드 확인을 위한 doAnswer 사용
+        doAnswer(invocation -> {
+            String currentThreadName = Thread.currentThread().getName();
+            assertThat(currentThreadName).startsWith("task-");  // @Async 기본 풀 이름 확인
+            return invocation.callRealMethod();
+        }).when(sseNotificationService).sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
+
+        // when: 알림 처리
+        notificationService.processNotification(request);
+
+        // then: 비동기 호출 확인 (verify로 메서드 호출)
+        verify(sseNotificationService, timeout(5000).times(1))
+                .sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
+    }
+}

--- a/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTest.java
@@ -1,7 +1,6 @@
 package com.grow.notification_service.notification.application;
 
 import com.grow.notification_service.notification.application.event.NotificationSavedEvent;
-import com.grow.notification_service.notification.application.exception.SseException;
 import com.grow.notification_service.notification.application.sse.SseSendService;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationJpaEntity;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
@@ -78,59 +76,5 @@ class NotificationServiceImplTest {
         assertThat(memberIdCaptor.getValue()).isEqualTo(memberId);
         assertThat(typeCaptor.getValue()).isEqualTo(NotificationType.MATCHING_SUCCESS);
         assertThat(messageCaptor.getValue()).isEqualTo("테스트 알림 내용");
-    }
-
-    @Test
-    @DisplayName("SSE 연결(emitter)이 없을 때 이벤트 발행 시 SseException이 발생하고 알림 전송이 실패하는지 확인")
-    void testEventPublishingFailureWithoutEmitter() {
-        // given: SSE 연결 없음 (emitter 미등록)
-        Long memberId = 1L;
-        NotificationRequestDto request = NotificationRequestDto.builder()
-                .memberId(memberId)
-                .notificationType(NotificationType.MATCHING_SUCCESS)
-                .content("테스트 알림 내용")
-                .build();
-
-        // when & then: 알림 처리 시 예외 발생 확인
-        notificationService.processNotification(request);  // DB 저장은 성공하지만 SSE 전송에서 예외
-
-        // DB 저장은 성공
-        List<NotificationJpaEntity> savedNotifications = notificationJpaRepository.findAll();
-        assertThat(savedNotifications).hasSize(1);
-
-        // 이벤트는 발행되었으나 SSE 전송에서 예외 발생
-        assertThrows(SseException.class, () -> sseSendService.sendNotification(
-                1L,
-                NotificationType.MATCHING_SUCCESS,
-                "테스트 알림 내용")
-        );
-    }
-
-    @Test
-    @DisplayName("이벤트 처리 메서드가 비동기(@Async)로 동작하는지 확인 (스레드 이름 검증)")
-    void testAsyncEventHandling() {
-        // given: SSE 연결 설정
-        Long memberId = 1L;
-        sseSendService.subscribe(memberId);
-
-        NotificationRequestDto request = NotificationRequestDto.builder()
-                .memberId(memberId)
-                .notificationType(NotificationType.MATCHING_SUCCESS)
-                .content("테스트 알림 내용")
-                .build();
-
-        // Spy로 sendNotification 메서드의 스레드 확인을 위한 doAnswer 사용
-        doAnswer(invocation -> {
-            String currentThreadName = Thread.currentThread().getName();
-            assertThat(currentThreadName).startsWith("task-");  // @Async 기본 풀 이름 확인
-            return invocation.callRealMethod();
-        }).when(sseSendService).sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
-
-        // when: 알림 처리
-        notificationService.processNotification(request);
-
-        // then: 비동기 호출 확인 (verify로 메서드 호출)
-        verify(sseSendService, timeout(5000).times(1))
-                .sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
     }
 }

--- a/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTestV2.java
+++ b/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTestV2.java
@@ -1,0 +1,61 @@
+package com.grow.notification_service.notification.application;
+
+import com.grow.notification_service.notification.application.exception.SseException;
+import com.grow.notification_service.notification.application.sse.SseSendService;
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationJpaEntity;
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import com.grow.notification_service.notification.infra.persistence.repository.NotificationJpaRepository;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class NotificationServiceImplTestV2 {
+
+    @Autowired
+    private NotificationServiceImpl notificationService;
+
+    @MockitoSpyBean
+    private SseSendService sseSendService;
+
+    @Autowired
+    private NotificationJpaRepository notificationJpaRepository;
+
+    @Test
+    @DisplayName("SSE 연결(emitter)이 없을 때 이벤트 발행 시 SseException이 발생하고 알림 전송이 실패하는지 확인")
+    void testEventPublishingFailureWithoutEmitter() {
+        // given: SSE 연결 없음 (emitter 미등록)
+        Long memberId = 10L;
+        NotificationRequestDto request = NotificationRequestDto.builder()
+                .memberId(memberId)
+                .notificationType(NotificationType.MATCHING_SUCCESS)
+                .content("테스트 알림 내용")
+                .build();
+
+        // when & then: 알림 처리 시 예외 발생 확인
+        notificationService.processNotification(request);  // DB 저장은 성공하지만 SSE 전송에서 예외
+
+        // DB 저장은 성공
+        List<NotificationJpaEntity> savedNotifications = notificationJpaRepository.findAll();
+        assertThat(savedNotifications).hasSize(1);
+
+        // 이벤트는 발행되었으나 SSE 전송에서 예외 발생
+        assertThrows(SseException.class, () -> sseSendService.sendNotification(
+                10L,
+                NotificationType.MATCHING_SUCCESS,
+                "테스트 알림 내용")
+        );
+    }
+}

--- a/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTestV3.java
+++ b/src/test/java/com/grow/notification_service/notification/application/NotificationServiceImplTestV3.java
@@ -1,0 +1,56 @@
+package com.grow.notification_service.notification.application;
+
+import com.grow.notification_service.notification.application.sse.SseSendService;
+import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class NotificationServiceImplTestV3 {
+
+    @Autowired
+    private NotificationServiceImpl notificationService;
+
+    @MockitoSpyBean
+    private SseSendService sseSendService;
+
+    @Test
+    @DisplayName("이벤트 처리 메서드가 비동기(@Async)로 동작하는지 확인 (스레드 이름 검증)")
+    void testAsyncEventHandling() {
+        // given: SSE 연결 설정
+        Long memberId = 1L;
+        sseSendService.subscribe(memberId);
+
+        NotificationRequestDto request = NotificationRequestDto.builder()
+                .memberId(memberId)
+                .notificationType(NotificationType.MATCHING_SUCCESS)
+                .content("테스트 알림 내용")
+                .build();
+
+        // Spy로 sendNotification 메서드의 스레드 확인을 위한 doAnswer 사용
+        doAnswer(invocation -> {
+            String currentThreadName = Thread.currentThread().getName();
+            assertThat(currentThreadName).startsWith("task-");  // @Async 기본 풀 이름 확인
+            return invocation.callRealMethod();
+        }).when(sseSendService).sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
+
+        // when: 알림 처리
+        notificationService.processNotification(request);
+
+        // then: 비동기 호출 확인 (verify로 메서드 호출)
+        verify(sseSendService, timeout(5000).times(1))
+                .sendNotification(any(Long.class), any(NotificationType.class), any(String.class));
+    }
+}

--- a/src/test/java/com/grow/notification_service/notification/application/sse/SseSendServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/notification/application/sse/SseSendServiceImplTest.java
@@ -23,10 +23,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
-class SseNotificationServiceImplTest {
+class SseSendServiceImplTest {
 
     @InjectMocks
-    private SseNotificationServiceImpl sseNotificationService;
+    private SseSendServiceImpl sseNotificationService;
 
     private Map<Long, SseEmitter> sseEmitters;
 


### PR DESCRIPTION
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)

+ 📸 Screenshot or Test Result
<img width="767" height="610" alt="스크린샷 2025-07-30 오후 9 51 53" src="https://github.com/user-attachments/assets/49b18380-e35d-470f-b475-5bc24700abd3" />
<img width="936" height="137" alt="스크린샷 2025-07-30 오후 10 04 09" src="https://github.com/user-attachments/assets/868cf7ca-6aad-4eb7-8e67-2d38785c6527" />

- 동일한 매칭 정보를 두 개 생성, 한 건씩 저장 (member Id 1, 2로 진행)
- 자동으로 유사도 점수 뽑아 주고, feign 으로 알림 서버에 전송됩니다

<img width="905" height="60" alt="스크린샷 2025-07-30 오후 10 05 55" src="https://github.com/user-attachments/assets/c9c12362-9c26-4718-9f30-9713869309cf" />
- 클라이언트 접속 시 sse 에 연결되었다고 가정

<img width="1719" height="437" alt="스크린샷 2025-07-30 오후 10 06 39" src="https://github.com/user-attachments/assets/c5d5eaaf-b632-415d-a5a0-f60451bc3e30" />

- 알림 서버에 자동으로 내역이 넘어 오고, DB 에 저장

- 비동기로 처리

- 매칭을 저장해서 유사한 사람을 찾은 본인 / 유사한 사람들 < 둘 다에게 알림 전송 확인

- 로그 내용은 어떤 것이 더 나은가 해서 본인 / 유사인 둘을 다르게 전송해 봤는데 유사인이 받는 게 더 매끄러운 거 같기도 하고요... 

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 매칭 서버를 8081 포트로 생성
    2. 알림 서버를 8080 포트로 생성
    3. 이후 member의 id 값만 다른 매칭을 저장 -> 자동으로 알림 서버에 전송되는지 확인
    4. 알림 서버에서는 DB에 저장하고 이를 sse 로 전송하는지 확인

## 🔗 Related Issues(필수)
Closes #{4}

## 📝 Note (주의 사항)
1. 아직 비동기 처리에 관한 오류 핸들러 등은 구현되지 않은 상황입니다
2. 글로벌 오류 핸들러 구현도 필요합니다
3. 세세한 오류 처리는 다음 PR에 추가하겠습니다 ^^7
4. CI 에 application.yml 추가해두겠습니다 (CI가 그래서 안 도네요...)
