### PR TITLE
✨ feat: Qna status 추가

### DIFF
--- a/src/main/java/com/grow/notification_service/qna/application/service/impl/QnaQueryServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/qna/application/service/impl/QnaQueryServiceImpl.java
@@ -29,6 +29,7 @@ public class QnaQueryServiceImpl implements QnaQueryService {
 	private final QnaPostRepository repository;
 	private final AuthorityCheckerPort authorityCheckerPort; // 관리자 검증
 
+	//TODO 외부 API 호출 분리하기
 	/** 관리자: 루트 QUESTION 기준 전체 스레드 조회 */
 	@Override
 	public QnaThreadResponse getThreadAsAdmin(Long rootQuestionId, Long viewerId) {

--- a/src/main/java/com/grow/notification_service/qna/domain/model/QnaPost.java
+++ b/src/main/java/com/grow/notification_service/qna/domain/model/QnaPost.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import java.time.Clock;
 import java.time.LocalDateTime;
 
+import com.grow.notification_service.common.exception.DomainException;
 import com.grow.notification_service.qna.domain.exception.QnaDomainException;
 import com.grow.notification_service.qna.domain.model.enums.QnaStatus;
 import com.grow.notification_service.qna.domain.model.enums.QnaType;
@@ -64,15 +65,6 @@ public class QnaPost {
 			QnaStatus.ACTIVE, LocalDateTime.now(clock), null);
 	}
 
-	/**
-	 * 삭제 처리
-	 * @return 삭제된 QnaPost
-	 */
-	public QnaPost delete() {
-		return new QnaPost(id, type, parentId, memberId, content,
-			QnaStatus.DELETED, createdAt, updatedAt);
-	}
-
 	/** 추가 질문 생성: ANSWER 아래에만 허용 (parent는 ANSWER의 id) */
 	public static QnaPost newFollowUpQuestion(Long memberId, Long answerId, String content, Clock clock) {
 		return new QnaPost(null, QnaType.QUESTION, answerId, memberId, content,
@@ -82,5 +74,15 @@ public class QnaPost {
 	/** parentId만 바꿔서 새 인스턴스를 리턴 */
 	public QnaPost withParentId(Long parentId) {
 		return new QnaPost(id, type, parentId, memberId, content, status, createdAt, updatedAt);
+	}
+
+	/** 체인형 QnA 규칙: 질문이 추가되면 스레드는 ACTIVE */
+	public static QnaStatus threadStatusOnQuestionAdded() {
+		return QnaStatus.ACTIVE;
+	}
+
+	/** 체인형 QnA 규칙: 답변이 추가되면 스레드는 COMPLETED */
+	public static QnaStatus threadStatusOnAnswerAdded() {
+		return QnaStatus.COMPLETED;
 	}
 }

--- a/src/main/java/com/grow/notification_service/qna/domain/model/enums/QnaStatus.java
+++ b/src/main/java/com/grow/notification_service/qna/domain/model/enums/QnaStatus.java
@@ -1,5 +1,5 @@
 package com.grow.notification_service.qna.domain.model.enums;
 
 public enum QnaStatus {
-	ACTIVE, DELETED
+	ACTIVE, COMPLETED
 }

--- a/src/main/java/com/grow/notification_service/qna/domain/repository/QnaPostRepository.java
+++ b/src/main/java/com/grow/notification_service/qna/domain/repository/QnaPostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.grow.notification_service.qna.domain.model.QnaPost;
+import com.grow.notification_service.qna.domain.model.enums.QnaStatus;
 import com.grow.notification_service.qna.domain.model.enums.QnaType;
 
 public interface QnaPostRepository {
@@ -20,4 +21,5 @@ public interface QnaPostRepository {
 	Page<QnaPost> findMyRootQuestions(Long memberId, Pageable pageable);
 	List<QnaPost> findTreeFlat(Long rootId);
 	boolean existsById(Long id);
+	int updateRootStatusFrom(Long startId, QnaStatus status);
 }

--- a/src/main/java/com/grow/notification_service/qna/infra/persistence/entity/QnaPostJpaEntity.java
+++ b/src/main/java/com/grow/notification_service/qna/infra/persistence/entity/QnaPostJpaEntity.java
@@ -28,10 +28,14 @@ import lombok.NoArgsConstructor;
 @Table(
 	name = "qna_post",
 	indexes = {
+		// parentId 단일: CTE 상향 탐색 최적화 (JOIN up u ON p.post_id = u.parent_id)
+		@Index(name = "idx_qna_parent", columnList = "parent_id"),
 		// parentId + createdAt: 트리 조회/정렬 최적화
 		@Index(name = "idx_qna_parent_created", columnList = "parent_id, created_at"),
 		// type + parentId: 질문/답변 필터 시
 		@Index(name = "idx_qna_type_parent", columnList = "type, parent_id"),
+		// type + parentId + createdAt: 복합 정렬/필터
+		@Index(name = "idx_qna_type_parent_created", columnList = "type, parent_id, created_at"),
 		// memberId + createdAt: 내 질문 목록
 		@Index(name = "idx_qna_member_created", columnList = "member_id, created_at")
 	}

--- a/src/main/java/com/grow/notification_service/qna/infra/persistence/repository/QnaPostJpaRepository.java
+++ b/src/main/java/com/grow/notification_service/qna/infra/persistence/repository/QnaPostJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,27 +22,66 @@ public interface QnaPostJpaRepository extends JpaRepository<QnaPostJpaEntity, Lo
 
 	Page<QnaPostJpaEntity> findByTypeAndParentIdIsNullOrderByCreatedAtDesc(QnaType type, Pageable pageable);
 
-	Page<QnaPostJpaEntity> findByTypeAndMemberIdAndParentIdIsNullOrderByCreatedAtDesc(QnaType type, Long memberId, Pageable pageable);
+	Page<QnaPostJpaEntity> findByTypeAndMemberIdAndParentIdIsNullOrderByCreatedAtDesc(QnaType type, Long memberId,
+		Pageable pageable);
 
+	/**
+	 * rootId(QUESTION)부터 시작해 parent-child 연결을 따라 모든 하위 노드를 재귀적으로 조회한다.
+	 * 루트 포함 전체 서브트리를 플랫 리스트로 반환한다.
+	 */
 	@Query(value = """
-    WITH RECURSIVE tree (
-      post_id, type, parent_id, member_id, content, status, created_at, updated_at
-    ) AS (
-      SELECT
-        post_id, type, parent_id, member_id, content, status, created_at, updated_at
-      FROM qna_post
-      WHERE post_id = :rootId
-      UNION ALL
-      SELECT
-        c.post_id, c.type, c.parent_id, c.member_id, c.content, c.status, c.created_at, c.updated_at
-      FROM qna_post c
-      JOIN tree t ON c.parent_id = t.post_id
-    )
-    SELECT
-      post_id, type, parent_id, member_id, content, status, created_at, updated_at
-    FROM tree
-    """, nativeQuery = true)
+		WITH RECURSIVE tree (
+		  post_id, type, parent_id, member_id, content, status, created_at, updated_at
+		) AS (
+		  SELECT
+		    post_id, type, parent_id, member_id, content, status, created_at, updated_at
+		  FROM qna_post
+		  WHERE post_id = :rootId
+		  UNION ALL
+		  SELECT
+		    c.post_id, c.type, c.parent_id, c.member_id, c.content, c.status, c.created_at, c.updated_at
+		  FROM qna_post c
+		  JOIN tree t ON c.parent_id = t.post_id
+		)
+		SELECT
+		  post_id, type, parent_id, member_id, content, status, created_at, updated_at
+		FROM tree
+		""", nativeQuery = true)
 	List<QnaPostJpaEntity> findTreeByRootId(@Param("rootId") Long rootId);
+
+	/**
+	 * startId에서 parent_id를 따라 상향으로 올라가 parent_id가 NULL이고 type이 QUESTION인 루트의 post_id를 조회한다.
+	 * 조회된 루트의 post_id를 한 건 반환한다. 없으면 null을 반환한다.
+	 */
+	@Query(value = """
+		WITH RECURSIVE up (id, parent_id, ptype) AS (
+		  SELECT post_id, parent_id, type
+		  FROM qna_post
+		  WHERE post_id = :startId
+		  UNION ALL
+		  SELECT p.post_id, p.parent_id, p.type
+		  FROM qna_post p
+		  JOIN up u ON p.post_id = u.parent_id
+		)
+		SELECT id
+		FROM up
+		WHERE parent_id IS NULL AND ptype = 'QUESTION'
+		FETCH FIRST 1 ROWS ONLY
+		""", nativeQuery = true)
+	Long findRootIdFromAny(@Param("startId") Long startId);
+
+	/**
+	 * 지정한 post_id 한 건의 status와 updated_at을 갱신한다.
+	 * 변경 대상은 전달된 rootId와 일치하는 행 한 건
+	 */
+	@Modifying(flushAutomatically = true, clearAutomatically = false)
+	@Query(value = """
+		UPDATE qna_post
+		SET status = :status,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE post_id = :rootId
+		""", nativeQuery = true)
+	int updateStatusById(@Param("rootId") Long rootId, @Param("status") String status);
 
 	boolean existsByPostId(Long postId);
 }

--- a/src/main/java/com/grow/notification_service/qna/infra/persistence/repository/QnaPostRepositoryImpl.java
+++ b/src/main/java/com/grow/notification_service/qna/infra/persistence/repository/QnaPostRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.grow.notification_service.qna.domain.model.QnaPost;
+import com.grow.notification_service.qna.domain.model.enums.QnaStatus;
 import com.grow.notification_service.qna.domain.model.enums.QnaType;
 import com.grow.notification_service.qna.domain.repository.QnaPostRepository;
 import com.grow.notification_service.qna.infra.persistence.entity.QnaPostJpaEntity;
@@ -137,6 +138,19 @@ public class QnaPostRepositoryImpl implements QnaPostRepository {
 			);
 		List<QnaPost> content = page.getContent().stream().map(QnaPostMapper::toDomain).toList();
 		return new PageImpl<>(content, pageable, page.getTotalElements());
+	}
+
+	/**
+	 * 시작 ID로부터 루트 질문의 상태 갱신
+	 * @param startId 시작 QnaPost ID (질문 또는 답변)
+	 * @param status 새 상태
+	 * @return 갱신된 행 수 (0 또는 1)
+	 */
+	@Override
+	@Transactional
+	public int updateRootStatusFrom(Long startId, QnaStatus status) {
+		Long rootId = jpa.findRootIdFromAny(startId);
+		return jpa.updateStatusById(rootId, status.name());
 	}
 
 	/**


### PR DESCRIPTION
## 🔍 Title(필수)
#17

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
### 질문 답변 전 상태
<img width="868" height="212" alt="스크린샷 2025-09-03 211652" src="https://github.com/user-attachments/assets/b28c6a09-829b-4291-a110-860f1f27d9c6" />
루트 질문이 ACTIVE 상태 ( 아직 추가 질문에 대한 답변이 달리지 않음)

### 질문 답변 완료 상태
<img width="932" height="192" alt="스크린샷 2025-09-03 211703" src="https://github.com/user-attachments/assets/8e3fd9e8-a94c-4a71-8a6b-a161f99c07b3" />
루트 질문이 COMPLETED 상태 (프론트에서 리스트로 조회할 때 루트 질문만 나오므로, 루트 질문에만 완료 처리를 하였습니다.)

### 백엔드 로그
<img width="564" height="241" alt="스크린샷 2025-09-03 211714" src="https://github.com/user-attachments/assets/b6323307-06fd-4a24-84fe-82107d5ad649" />


## 🔗 Related Issues(필수)
Closes #17 

## 📝 Note (주의 사항)
루트 질문의 상태를 ACTIVE, DELETE에서 ACTIVE,COMPLETED로 변경했습니다.
질문에 대한 답변이 달리지 않으면 ACTIVE 상태, 질문에 대한 답변이 달리면 COMPLETED 상태로 전이합니다. 
스레드 조회하는 것과 마찬가지로 CTE를 사용했습니다. (H2는 WITH RECURSIVE를 UPDATE와 함께 쓸 수 없어서 2개의 메서드로 분리했습니다.)

대략적인 그림

1) 루트 질문만 있고 답변 없음
``` 
(1) Q: 루트 질문 [ACTIVE]
```

2) 꼬리 질문까지 답변 완료
```
(1) Q: 루트 질문 [ACTIVE]
 └─ (2) A: 운영자 답변       → 루트(1) 상태: COMPLETED

    (꼬리 질문 생성 시)
    루트(1) 상태: ACTIVE
    └─ (2) A
       └─ (3) Q: 꼬리 질문 [ACTIVE]

          (꼬리 답변 달리면)
          └─ (4) A: 꼬리 답변   → 루트(1) 상태: COMPLETED 
```


