### PR TITLE
✨ feat: Kafka 메시지 수신을 위한 컨슈머 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,10 @@ dependencies {
 
 	// kafka
 	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation "org.springframework.kafka:spring-kafka-test"
+
+	// slack
+	implementation 'com.slack.api:slack-api-client:1.43.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// feign

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// feign
 	implementation platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0")
@@ -118,6 +120,9 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 	implementation 'com.danielfrak.code:springdoc-openapi-externalized-documentation:1.0.0'
+
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/notification_service/global/config/JsonUtils.java
+++ b/src/main/java/com/grow/notification_service/global/config/JsonUtils.java
@@ -1,0 +1,35 @@
+package com.grow.notification_service.global.config;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Component
+public class JsonUtils {
+	private static final ObjectMapper objectMapper = new ObjectMapper()
+		.registerModule(new JavaTimeModule())                 // LocalDateTime 지원
+		.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 문자열로 직렬화
+
+	private JsonUtils() {
+	}
+	/**
+	 * 주어진 객체를 JSON 문자열로 변환합니다.
+	 *
+	 * 이 메서드는 Jackson의 ObjectMapper를 사용하여 객체를 직렬화합니다.
+	 * 변환 중 오류가 발생하면 RuntimeException을 던집니다.
+	 *
+	 * @param object JSON으로 변환할 객체. null이 허용되며, null은 "null" 문자열로 변환됩니다.
+	 * @return 객체를 나타내는 JSON 문자열.
+	 * @throws RuntimeException JSON 직렬화에 실패할 경우 발생합니다. 내부적으로 JsonProcessingException을 래핑합니다.
+	 */
+	public static <T> T fromJson(String json, Class<T> type) {
+		try {
+			return objectMapper.readValue(json, type);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("JSON 역직렬화 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
@@ -1,0 +1,44 @@
+package com.grow.notification_service.notification.infra.kafka;
+
+import com.grow.notification_service.global.config.JsonUtils;
+import com.grow.notification_service.notification.application.service.NotificationService;
+import com.grow.notification_service.notification.presentation.dto.NotificationRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationRequestedConsumer {
+
+	private final NotificationService notificationService;
+	private final JsonUtils json; // 공용 ObjectMapper 쓰는 util(Bean)
+
+	/**
+	 * Kafka "member.notification.requested" 토픽에서 메시지를 수신합니다.
+	 * 메시지 페이로드를 NotificationRequestDto로 역직렬화하고,
+	 * NotificationService를 통해 알림 처리를 수행합니다.
+	 * 수신된 메시지와 처리 결과를 로그에 기록합니다.
+	 * 예외 발생 시 에러 로그를 남기고, 필요 시 DLQ 재전송 로직을 추가할 수 있습니다.
+	 * @param payload Kafka 메시지의 JSON 페이로드
+ 	 */
+	@KafkaListener(
+		topics = "member.notification.requested",
+		groupId = "notification-service"
+	)
+	public void onMessage(String payload) {
+		// 1. 페이로드를 NotificationRequestDto로 역직렬화
+		// 2. NotificationService를 통해 알림 처리
+		// 3. 처리 결과를 로그에 기록
+		try {
+			NotificationRequestDto dto = json.fromJson(payload, NotificationRequestDto.class);
+			notificationService.processNotification(dto);
+			log.info("[KAFKA][RECV] notification.requested -> memberId={}, type={}",
+				dto.getMemberId(), dto.getNotificationType());
+		} catch (Exception e) {
+			log.error("[KAFKA][RECV][ERROR] payload={}", payload, e);
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 public class NotificationRequestedConsumer {
 
 	private final NotificationService notificationService;
-	private final JsonUtils json; // 공용 ObjectMapper 쓰는 util(Bean)
 
 	/**
 	 * Kafka "member.notification.requested" 토픽에서 메시지를 수신합니다.
@@ -33,7 +32,7 @@ public class NotificationRequestedConsumer {
 		// 2. NotificationService를 통해 알림 처리
 		// 3. 처리 결과를 로그에 기록
 		try {
-			NotificationRequestDto dto = json.fromJson(payload, NotificationRequestDto.class);
+			NotificationRequestDto dto = JsonUtils.fromJson(payload, NotificationRequestDto.class);
 			notificationService.processNotification(dto);
 			log.info("[KAFKA][RECV] member.notification.requested -> memberId={}, type={}",
 				dto.getMemberId(), dto.getNotificationType());

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
@@ -35,7 +35,7 @@ public class NotificationRequestedConsumer {
 		try {
 			NotificationRequestDto dto = json.fromJson(payload, NotificationRequestDto.class);
 			notificationService.processNotification(dto);
-			log.info("[KAFKA][RECV] notification.requested -> memberId={}, type={}",
+			log.info("[KAFKA][RECV] member.notification.requested -> memberId={}, type={}",
 				dto.getMemberId(), dto.getNotificationType());
 		} catch (Exception e) {
 			log.error("[KAFKA][RECV][ERROR] payload={}", payload, e);

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumer.java
@@ -1,0 +1,63 @@
+package com.grow.notification_service.notification.infra.kafka;
+
+import com.slack.api.Slack;
+import com.slack.api.webhook.WebhookPayloads;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import static com.slack.api.model.block.Blocks.*;
+import static com.slack.api.model.block.composition.BlockCompositions.*;
+
+/**
+ * 알림 요청 이벤트가 재시도 끝에 실패(DLT 도착)했을 때 처리하는 Consumer
+ * - 로그/모니터링 동일 규격 유지
+ * - 슬랙 웹훅 알림 전송
+ */
+@Slf4j
+@Service
+public class NotificationRequestedEventDltConsumer {
+
+	@Value("${slack.webhook.url}")
+	private String slackWebhookUrl;
+
+	@KafkaListener(
+		topics = "member.notification.requested.dlt",
+		groupId = "notification-dlt-service"
+	)
+	public void consumeNotificationRequestedDlt(String message) {
+		log.info("[NOTIFICATION DLT] 알림 요청 실패 이벤트 수신: {}", message == null ? "" : message.trim());
+
+		// TODO 로그 시스템에 전송 or 모니터링 카운트 증가 + 슬랙 URL 받아서 테스트 해봐야함
+
+		// 슬랙으로 알림 전송
+		Slack slack = Slack.getInstance();
+
+		// 현재 시간(KST) 동적 생성
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+		String currentTime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+		// 에러 메시지 구성
+		String errorDetails =
+			"카테고리: [NOTIFICATION]\n" +
+				"상세: 알림 처리에 실패하였습니다.\n" +
+				"발생 시간: " + currentTime + "\n" +
+				"영향: 사용자에게 알림 전송이 누락되어 안내 지연 가능";
+
+		try {
+			slack.send(slackWebhookUrl, WebhookPayloads.payload(p -> p.blocks(asBlocks(
+				header(h -> h.text(plainText("⚠️ 오류 알림: 알림 요청 이벤트 수신 실패", true))),
+				section(s -> s.text(plainText(errorDetails)))
+			))));
+		} catch (IOException e) {
+			log.warn("[NOTIFICATION DLT] 알림 요청 실패 이벤트 수신 실패: {}", e.getMessage());
+			throw new RuntimeException("slack 에 오류 메시지 전송 실패", e);
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/notification/presentation/dto/NotificationRequestDto.java
+++ b/src/main/java/com/grow/notification_service/notification/presentation/dto/NotificationRequestDto.java
@@ -1,11 +1,13 @@
 
 package com.grow.notification_service.notification.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.grow.notification_service.notification.infra.persistence.entity.NotificationType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
 
 import java.time.LocalDateTime;
 
@@ -21,6 +23,8 @@ import java.time.LocalDateTime;
  */
 @Getter
 @Builder
+@Jacksonized
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class NotificationRequestDto {
 
     /**

--- a/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumerTest.java
+++ b/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumerTest.java
@@ -1,0 +1,58 @@
+package com.grow.notification_service.notification.infra.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grow.notification_service.global.config.JsonUtils;
+import com.grow.notification_service.notification.application.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+class NotificationRequestedConsumerTest {
+
+	private NotificationService notificationService; // mock
+	private JsonUtils json;                          // real
+	private NotificationRequestedConsumer consumer;  // SUT
+
+	@BeforeEach
+	void setUp() {
+		notificationService = mock(NotificationService.class);
+		consumer = new NotificationRequestedConsumer(notificationService, json);
+	}
+
+	@Test
+	void onMessage_success_withObjectMapper() throws Exception {
+		ObjectMapper mapper = new ObjectMapper();
+		String payload = mapper.writeValueAsString(
+			Map.of(
+				"memberId", 14,
+				"code", "ADDR_REMINDER",
+				"notificationType", "SERVICE_NOTICE",
+				"title", "주소 정보 미입력",
+				"content", "더 정확한 매칭을 위해 주소 정보를 등록해 주세요.",
+				"occurredAt", "2025-09-06T18:29:46.4550951"
+			)
+		);
+
+		consumer.onMessage(payload);
+
+		verify(notificationService, times(1)).processNotification(any());
+	}
+
+	@Test
+	@DisplayName("깨진 JSON이면 컨슈머가 예외를 잡고 Service는 호출하지 않음")
+	void onMessage_badJson() {
+		// given: 명백히 잘못된 JSON
+		String badPayload = "{ not-a-json ";
+
+		// when: 컨슈머가 try-catch로 예외를 먹고 로그만 남겨야 함
+		consumer.onMessage(badPayload);
+
+		// then: 서비스 호출 안 됨
+		verify(notificationService, never()).processNotification(any());
+	}
+}

--- a/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumerTest.java
+++ b/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class NotificationRequestedConsumerTest {
@@ -52,10 +53,11 @@ class NotificationRequestedConsumerTest {
 	@Test
 	@DisplayName("깨진 JSON이면 예외를 잡고 서비스는 호출하지 않음")
 	void onMessage_badJson() {
-		String badPayload = "{ not-a-json ";
+		// given
+		String payload = "{ not-a-json";
 
-		consumer.onMessage(badPayload);
-
+		// when & then
+		assertThrows(RuntimeException.class, () -> consumer.onMessage(payload));
 		verify(notificationService, never()).processNotification(any());
 	}
 }

--- a/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumerTest.java
+++ b/src/test/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumerTest.java
@@ -1,0 +1,71 @@
+package com.grow.notification_service.notification.infra.kafka;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@EmbeddedKafka(
+	partitions = 1,
+	topics = { "member.notification.requested", "member.notification.requested.dlt" }
+)
+@DirtiesContext
+@TestPropertySource(properties = {
+	"spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+	// 재시도 즉시 종료 → 바로 DLT로
+	"grow.kafka.retry.attempts=1",
+	"grow.kafka.retry.delay-ms=0",
+	"grow.kafka.retry.max-delay-ms=0"
+})
+class NotificationRequestedEventDltConsumerTest {
+
+	@Autowired EmbeddedKafkaBroker broker;
+	@Autowired KafkaTemplate<String, String> kafkaTemplate;
+
+	private Consumer<String, String> dltConsumer() {
+		Map<String, Object> props = KafkaTestUtils.consumerProps(
+			"dlt-smoke-" + UUID.randomUUID(), "true", broker);
+		Consumer<String, String> c = new org.apache.kafka.clients.consumer.KafkaConsumer<>(
+			props, new StringDeserializer(), new StringDeserializer());
+		c.subscribe(java.util.List.of("member.notification.requested.dlt"));
+		return c;
+	}
+
+	@Test
+	@Timeout(20)
+	void badJson_goes_to_dlt() {
+		// given
+		String key = "k1";
+		String badPayload = "{ not-a-json ";
+
+		// when
+		kafkaTemplate.send("member.notification.requested", key, badPayload);
+
+		// then
+		try (Consumer<String, String> consumer = dltConsumer()) {
+			ConsumerRecord<String, String> rec =
+				KafkaTestUtils.getSingleRecord(consumer,
+					"member.notification.requested.dlt",
+					Duration.ofSeconds(30));
+
+			assertEquals(key, rec.key());
+			assertEquals(badPayload, rec.value());
+		}
+	}
+}


### PR DESCRIPTION
## 🔍 Title(필수)
#21 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
<img width="880" height="167" alt="image" src="https://github.com/user-attachments/assets/630e2c1d-d542-4c3d-91a1-27231999f67e" />
<img width="968" height="563" alt="image" src="https://github.com/user-attachments/assets/8d3ecd15-cd78-49df-b804-2171a6b19dfa" />

## 🔍 Test
- 변경 사항을 검증하는 방법을 명시
- 예:
    1. 로컬 서버 실행 (`npm start`)
    2. `/login` 페이지에서 로그인 시도
    3. 성공 메시지 확인

## 🔗 Related Issues(필수)
Closes #21

## 📝 Note (주의 사항)
멤버 서비스에서 발행한 "member.notification.requested" 토픽 컨슈머 구현했습니다. 같은 처리방식/스키마라면 해당 클래스에 토픽 추가해서 쓰면 될 것 같아요(혹시 문제가 잇으면 리뷰 부탁드립니다)
멤버 서비스의 프로듀서 코드도 정리만 해서 올리겠습니다

