### PR TITLE
✨ feat: Q&A 알림 이벤트 추가

### DIFF
--- a/src/main/java/com/grow/notification_service/global/config/KafkaTopicConfig.java
+++ b/src/main/java/com/grow/notification_service/global/config/KafkaTopicConfig.java
@@ -1,0 +1,15 @@
+package com.grow.notification_service.global.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.TopicBuilder;
+
+public class KafkaTopicConfig {
+	@Bean
+	public NewTopic qnaNotificationRequested() {
+		return TopicBuilder.name("qna.notification.requested")
+			.partitions(3)
+			.replicas(3)
+			.build();
+	}
+}

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedConsumer.java
@@ -26,7 +26,7 @@ public class NotificationRequestedConsumer {
 	 * @param payload Kafka 메시지의 JSON 페이로드
  	 */
 	@KafkaListener(
-		topics = {"member.notification.requested", "point.notification.requested", "payment.notification.requested"},
+		topics = {"member.notification.requested", "point.notification.requested", "payment.notification.requested", "qna.notification.requested"},
 		groupId = "notification-service",
 		concurrency = "3"
 	)

--- a/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumer.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/kafka/NotificationRequestedEventDltConsumer.java
@@ -68,4 +68,18 @@ public class NotificationRequestedEventDltConsumer {
 
 		log.info("[NOTIFICATION DLT][PAYMENT] 처리 완료");
 	}
+
+	@KafkaListener(
+		topics = "qna.notification.requested.dlt",
+		groupId = "notification-dlt-qna-service"
+	)
+	public void consumeQnaDlt(String message) {
+		log.info("[NOTIFICATION DLT][QNA] 수신: {}", message == null ? "" : message.trim());
+		slackErrorSendService.sendError(
+			"QnA 알림 - 전송 실패",
+			"카테고리: [QNA -> NOTIFICATION]\n상세: QnA 관련 알림 전송에 실패하였습니다.\n영향: 사용자에게 알림이 수신되지 않아 안내 지연 가능",
+			message
+		);
+		log.info("[NOTIFICATION DLT][QNA] 처리 완료");
+	}
 }

--- a/src/main/java/com/grow/notification_service/notification/infra/persistence/entity/NotificationType.java
+++ b/src/main/java/com/grow/notification_service/notification/infra/persistence/entity/NotificationType.java
@@ -15,6 +15,7 @@ public enum NotificationType {
     INQUIRY_ANSWER("[문의 답변]"),
     REVIEW("[리뷰]"),
     PAYMENT("[결제]"),
+    QNA("[Q&A]"),
 
     GROUP_JOIN_REQUEST("[그룹 참여 요청]"),
     GROUP_JOIN_APPROVAL("[그룹 참여 승인]"),

--- a/src/main/java/com/grow/notification_service/qna/application/event/QnaNotificationEvent.java
+++ b/src/main/java/com/grow/notification_service/qna/application/event/QnaNotificationEvent.java
@@ -1,0 +1,16 @@
+package com.grow.notification_service.qna.application.event;
+
+import java.time.LocalDateTime;
+
+import com.grow.notification_service.chatbot.infra.persistence.enums.QNA;
+
+public record QnaNotificationEvent(
+	Long memberId,
+	String code,
+	String notificationType,
+	String title,
+	String content,
+	Long answerId,
+	LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/grow/notification_service/qna/application/event/QnaNotificationProducer.java
+++ b/src/main/java/com/grow/notification_service/qna/application/event/QnaNotificationProducer.java
@@ -1,0 +1,44 @@
+package com.grow.notification_service.qna.application.event;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import com.grow.notification_service.global.util.JsonUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QnaNotificationProducer {
+
+	private static final String TYPE = "QNA";
+	private static final String CODE_ANSWER_ADDED = "ANSWER_ADDED";
+	private static final String TOPIC = "qna.notification.requested";
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final Clock clock;
+
+	public void answerAdded(Long recipientMemberId, Long answerId) {
+		String content = "내 질문에 새로운 답변이 달렸어요.";
+		LocalDateTime now = LocalDateTime.now(clock);
+
+		QnaNotificationEvent event = new QnaNotificationEvent(
+			recipientMemberId,
+			CODE_ANSWER_ADDED,
+			TYPE,
+			null,
+			content,
+			answerId,
+			now
+		);
+
+		String key = String.valueOf(recipientMemberId);
+		String payload = JsonUtils.toJsonString(event);
+
+		kafkaTemplate.send(TOPIC, key, payload);
+		log.info("[KAFKA][SENT] topic={}, key={}, code={}, answerId={}",
+			TOPIC, key, CODE_ANSWER_ADDED, answerId);
+	}
+}

--- a/src/test/java/com/grow/notification_service/qna/application/service/impl/QnaCommandServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/qna/application/service/impl/QnaCommandServiceImplTest.java
@@ -2,6 +2,7 @@ package com.grow.notification_service.qna.application.service.impl;
 
 import com.grow.notification_service.global.exception.ErrorCode;
 import com.grow.notification_service.global.exception.QnaException;
+import com.grow.notification_service.qna.application.event.QnaNotificationProducer;
 import com.grow.notification_service.qna.application.port.AuthorityCheckerPort;
 import com.grow.notification_service.qna.domain.model.QnaPost;
 import com.grow.notification_service.qna.domain.model.enums.QnaStatus;
@@ -16,7 +17,6 @@ import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.*;
-
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +33,9 @@ class QnaCommandServiceImplTest {
 	@Mock
 	AuthorityCheckerPort authorityCheckerPort;
 
+	@Mock
+	QnaNotificationProducer qnaNotificationProducer;
+
 	Clock fixedClock;
 
 	QnaCommandServiceImpl service;
@@ -40,7 +43,7 @@ class QnaCommandServiceImplTest {
 	@BeforeEach
 	void setUp() {
 		fixedClock = Clock.fixed(Instant.parse("2025-09-04T12:00:00Z"), ZoneId.of("UTC"));
-		service = new QnaCommandServiceImpl(repository, authorityCheckerPort, fixedClock);
+		service = new QnaCommandServiceImpl(repository, authorityCheckerPort, fixedClock, qnaNotificationProducer);
 	}
 
 	@Nested
@@ -50,15 +53,12 @@ class QnaCommandServiceImplTest {
 		@Test
 		@DisplayName("성공: 루트 질문 생성 (parentId=null) → 저장 & 상태 업데이트 없음")
 		void create_root_question_success() {
-			// given
 			Long memberId = 10L;
 			String content = "게이트웨이에서 권한을 어떻게 전달하나요?";
 			when(repository.save(any(QnaPost.class))).thenReturn(100L);
 
-			// when
 			Long postId = service.createQuestion(memberId, content, null);
 
-			// then
 			assertThat(postId).isEqualTo(100L);
 			ArgumentCaptor<QnaPost> cap = ArgumentCaptor.forClass(QnaPost.class);
 			verify(repository).save(cap.capture());
@@ -76,12 +76,14 @@ class QnaCommandServiceImplTest {
 			);
 
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			// 질문 생성은 알림 발행 대상 아님
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 
 		@Test
 		@DisplayName("성공: 추가 질문 생성 (parent=ANSWER) → 루트 상태 ACTIVE로 토글")
 		void create_followup_question_success() {
-			// given
 			Long memberId = 20L;
 			Long answerId = 200L;
 			String content = "카프카로 이벤트 전파하면 되나요?";
@@ -97,10 +99,8 @@ class QnaCommandServiceImplTest {
 			when(repository.save(any(QnaPost.class))).thenReturn(300L);
 			when(repository.updateRootStatusFrom(eq(answerId), eq(QnaStatus.ACTIVE))).thenReturn(1);
 
-			// when
 			Long newId = service.createQuestion(memberId, content, answerId);
 
-			// then
 			assertThat(newId).isEqualTo(300L);
 
 			ArgumentCaptor<QnaPost> cap = ArgumentCaptor.forClass(QnaPost.class);
@@ -116,12 +116,14 @@ class QnaCommandServiceImplTest {
 			);
 
 			verify(repository).updateRootStatusFrom(answerId, QnaStatus.ACTIVE);
+
+			// 추가 질문도 알림 발행 없음
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 
 		@Test
 		@DisplayName("실패: parentId가 ANSWER가 아니면 INVALID_QNA_PARENT")
 		void create_followup_question_invalid_parent_type() {
-			// given
 			Long parentId = 777L;
 			QnaPost parentQuestion = new QnaPost(
 				parentId, QnaType.QUESTION, null, 1L, "부모 질문",
@@ -131,31 +133,30 @@ class QnaCommandServiceImplTest {
 			);
 			when(repository.findById(parentId)).thenReturn(Optional.of(parentQuestion));
 
-			// when
 			QnaException ex = assertThrows(QnaException.class,
 				() -> service.createQuestion(10L, "추가 질문", parentId));
 
-			// then
 			assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_QNA_PARENT);
 			verify(repository, never()).save(any());
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 
 		@Test
 		@DisplayName("실패: parentId 조회 불가 → QNA_NOT_FOUND")
 		void create_followup_question_parent_not_found() {
-			// given
 			Long parentId = 555L;
 			when(repository.findById(parentId)).thenReturn(Optional.empty());
 
-			// when
 			QnaException ex = assertThrows(QnaException.class,
 				() -> service.createQuestion(10L, "추가 질문", parentId));
 
-			// then
 			assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.QNA_NOT_FOUND);
 			verify(repository, never()).save(any());
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 	}
 
@@ -164,29 +165,27 @@ class QnaCommandServiceImplTest {
 	class CreateAnswer {
 
 		@Test
-		@DisplayName("성공: 관리자만 답변 가능, parent=QUESTION → 저장 & 루트 상태 COMPLETED")
+		@DisplayName("성공: 관리자만 답변 가능, parent=QUESTION → 저장 & 루트 상태 COMPLETED + 질문작성자에게 알림 발행")
 		void create_answer_success_admin() {
-			// given
 			Long adminId = 1L;
 			Long questionId = 1000L;
+			Long questionOwnerId = 30L; // 질문 작성자 (알림 수신자)
 			String content = "게이트웨이가 JWT 파싱 후 X-Authorization-Id, X-Role 헤더로 전달하세요.";
 
 			when(authorityCheckerPort.isAdmin(adminId)).thenReturn(true);
 
 			QnaPost parentQuestion = new QnaPost(
-				questionId, QnaType.QUESTION, null, 30L, "루트 질문",
+				questionId, QnaType.QUESTION, null, questionOwnerId, "루트 질문",
 				QnaStatus.ACTIVE,
 				LocalDateTime.now(fixedClock),
 				null
 			);
 			when(repository.findById(questionId)).thenReturn(Optional.of(parentQuestion));
-			when(repository.save(any(QnaPost.class))).thenReturn(2000L);
+			when(repository.save(any(QnaPost.class))).thenReturn(2000L); // answerId
 			when(repository.updateRootStatusFrom(eq(questionId), eq(QnaStatus.COMPLETED))).thenReturn(1);
 
-			// when
 			Long newAnswerId = service.createAnswer(adminId, questionId, content);
 
-			// then
 			assertThat(newAnswerId).isEqualTo(2000L);
 
 			ArgumentCaptor<QnaPost> cap = ArgumentCaptor.forClass(QnaPost.class);
@@ -203,46 +202,45 @@ class QnaCommandServiceImplTest {
 			);
 
 			verify(repository).updateRootStatusFrom(questionId, QnaStatus.COMPLETED);
+
+			verify(qnaNotificationProducer).answerAdded(eq(questionOwnerId), eq(2000L));
 		}
 
 		@Test
-		@DisplayName("실패: 비관리자는 NO_PERMISSION_TO_WRITE_ANSWER")
+		@DisplayName("실패: 비관리자는 NO_PERMISSION_TO_WRITE_ANSWER (알림 발행 없음)")
 		void create_answer_non_admin_forbidden() {
-			// given
 			when(authorityCheckerPort.isAdmin(2L)).thenReturn(false);
 
-			// when
 			QnaException ex = assertThrows(QnaException.class,
 				() -> service.createAnswer(2L, 10L, "비관리자 답변"));
 
-			// then
 			assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NO_PERMISSION_TO_WRITE_ANSWER);
 			verify(repository, never()).findById(anyLong());
 			verify(repository, never()).save(any());
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 
 		@Test
-		@DisplayName("실패: parent 질문이 존재하지 않으면 QNA_NOT_FOUND")
+		@DisplayName("실패: parent 질문이 존재하지 않으면 QNA_NOT_FOUND (알림 발행 없음)")
 		void create_answer_parent_not_found() {
-			// given
 			when(authorityCheckerPort.isAdmin(1L)).thenReturn(true);
 			when(repository.findById(999L)).thenReturn(Optional.empty());
 
-			// when
 			QnaException ex = assertThrows(QnaException.class,
 				() -> service.createAnswer(1L, 999L, "답변"));
 
-			// then
 			assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.QNA_NOT_FOUND);
 			verify(repository, never()).save(any());
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 
 		@Test
-		@DisplayName("실패: parent 타입이 QUESTION이 아니면 INVALID_QNA_PARENT")
+		@DisplayName("실패: parent 타입이 QUESTION이 아니면 INVALID_QNA_PARENT (알림 발행 없음)")
 		void create_answer_invalid_parent_type() {
-			// given
 			when(authorityCheckerPort.isAdmin(1L)).thenReturn(true);
 
 			Long parentId = 333L;
@@ -254,14 +252,14 @@ class QnaCommandServiceImplTest {
 			);
 			when(repository.findById(parentId)).thenReturn(Optional.of(parent));
 
-			// when
 			QnaException ex = assertThrows(QnaException.class,
 				() -> service.createAnswer(1L, parentId, "잘못된 부모 타입"));
 
-			// then
 			assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.INVALID_QNA_PARENT);
 			verify(repository, never()).save(any());
 			verify(repository, never()).updateRootStatusFrom(anyLong(), any());
+
+			verifyNoInteractions(qnaNotificationProducer);
 		}
 	}
 }


### PR DESCRIPTION
## 🔍 Title(필수)
#28 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

### 백엔드 로그
<img width="1527" height="250" alt="스크린샷 2025-09-09 233602" src="https://github.com/user-attachments/assets/7b7c84de-2ac8-4070-98e1-c4f535d7d939" />

### 프론트 알림 작성 UI
<img width="1006" height="486" alt="스크린샷 2025-09-09 231658" src="https://github.com/user-attachments/assets/676d173a-b4fd-4953-af0f-632887803c4e" />
<img width="1026" height="690" alt="스크린샷 2025-09-09 231703" src="https://github.com/user-attachments/assets/f0ef453c-69fa-47be-ac79-83df1ed28c7c" />

### 프론트 알림 도착 확인
<img width="993" height="294" alt="스크린샷 2025-09-09 233009" src="https://github.com/user-attachments/assets/91dec40e-dfeb-46cd-99cb-f02c904be1ed" />
<img width="394" height="88" alt="스크린샷 2025-09-09 233548" src="https://github.com/user-attachments/assets/d9500f35-fbbf-4cf8-9c3e-71d4fe0e5c6c" />


## 🔗 Related Issues(필수)
Closes #28

## 📝 Note (주의 사항)
문의에 답변 달렸을 시 알림 보내는 카프카 이벤트 추가했습니다
그리고 프론트에 제가 1:1문의 작성 버튼을 안 만들었더라구요.. 수정했습니다.
이제 쪽지 알림만 만들면 대강 끝날듯..? 또 카프카 달아야 할 게 있나 찾아봐야겟네요