### PR TITLE
✨ feat: 회원의 퀴즈 풀이 이력 기반으로 복습 문제 출제 기능 추가

### DIFF
--- a/src/main/java/com/grow/notification_service/global/exception/ErrorCode.java
+++ b/src/main/java/com/grow/notification_service/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
 	INVALID_SKILL_TAG(HttpStatus.BAD_REQUEST, "400-4", "invalid.skill.tag"),
 	UNSUPPORTED_MODE(HttpStatus.BAD_REQUEST, "400-5", "unsupported.mode"),
 	QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "404-3", "quiz.not.found"),
-	CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "400-6", "category.mismatch"),;
+	CATEGORY_MISMATCH(HttpStatus.BAD_REQUEST, "400-6", "category.mismatch"),
+	NOT_ENOUGH_HISTORY(HttpStatus.BAD_REQUEST, "400-7", "not.enough.history"),;
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/grow/notification_service/quiz/application/MemberQuizResultPort.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/MemberQuizResultPort.java
@@ -9,4 +9,13 @@ public interface MemberQuizResultPort {
 	 * @return 정답인 퀴즈 ID 목록
 	 */
 	List<Long> findCorrectQuizIds(Long memberId);
+
+	/**
+	 * 특정 카테고리에서 맞춘/틀린 퀴즈 ID 목록 조회
+	 * @param memberId 회원 ID
+	 * @param categoryId 카테고리 ID
+	 * @param correct 맞춘 여부 (true: 맞춘 퀴즈, false: 틀린 퀴즈, null: 전체)
+	 * @return 퀴즈 ID 목록
+	 */
+	List<Long> findAnsweredQuizIds(Long memberId, Long categoryId, Boolean correct);
 }

--- a/src/main/java/com/grow/notification_service/quiz/application/service/QuizApplicationService.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/service/QuizApplicationService.java
@@ -10,4 +10,9 @@ public interface QuizApplicationService {
 	List<QuizItem> pickQuizByMode(Long memberId, String skillTagCode, String mode);
 
 	SubmitAnswersResponse submitAnswers(Long memberId, SubmitAnswersRequest req);
+
+	List<QuizItem> pickReviewByHistory(
+		Long memberId, String skillTagCode, String mode,
+		Integer totalOpt, Double wrongRatioOpt
+	);
 }

--- a/src/main/java/com/grow/notification_service/quiz/domain/repository/QuizRepository.java
+++ b/src/main/java/com/grow/notification_service/quiz/domain/repository/QuizRepository.java
@@ -17,4 +17,8 @@ public interface QuizRepository {
 	boolean existsByCategoryIdAndQuestion(Long categoryId, String question);
 
 	List<Quiz> pick(Long categoryId, QuizLevel level, List<Long> excludedQuizIds, Pageable pageable);
+
+	List<Quiz> pickFromIncludeIds(Long categoryId, QuizLevel level, List<Long> includeIds, Pageable pageable);
+
+	List<Quiz> pickFillRandomExcluding(Long categoryId, QuizLevel level, List<Long> excludedIds, Pageable pageable);
 }

--- a/src/main/java/com/grow/notification_service/quiz/domain/service/QuizReviewService.java
+++ b/src/main/java/com/grow/notification_service/quiz/domain/service/QuizReviewService.java
@@ -1,0 +1,36 @@
+package com.grow.notification_service.quiz.domain.service;
+
+import java.util.List;
+
+import com.grow.notification_service.quiz.domain.model.Quiz;
+
+public class QuizReviewService {
+
+	public static final int DEFAULT_TOTAL = 5;
+	public static final double DEFAULT_WRONG_RATIO = 0.6;
+	public static final int MIN_HISTORY = 5;
+
+	public record Need(int wrong, int correct) {}
+
+	/**
+	 * 최소 풀이 이력 충족 여부 확인
+	 */
+	public boolean hasEnoughHistory(List<Quiz> history) {
+		return history != null && history.size() >= MIN_HISTORY;
+	}
+
+	/**
+	 * 필요한 정/오답 개수 계산
+	 */
+	public Need computeNeeds(int totalOpt, Double wrongRatioOpt) {
+		int total = (totalOpt <= 0) ? DEFAULT_TOTAL : totalOpt;
+		double wrongRatio = (wrongRatioOpt == null || wrongRatioOpt <= 0.0 || wrongRatioOpt >= 1.0)
+			? DEFAULT_WRONG_RATIO : wrongRatioOpt;
+
+		int wrongNeed = (int) Math.ceil(total * wrongRatio);
+		if (wrongNeed > total) wrongNeed = total;
+		int correctNeed = total - wrongNeed;
+
+		return new Need(wrongNeed, correctNeed);
+	}
+}

--- a/src/main/java/com/grow/notification_service/quiz/infra/persistence/repository/QuizJpaRepository.java
+++ b/src/main/java/com/grow/notification_service/quiz/infra/persistence/repository/QuizJpaRepository.java
@@ -59,4 +59,40 @@ public interface QuizJpaRepository
 		QuizLevel level,
 		List<Long> excludedIds,
 		Pageable pageable);
+
+	/**
+	 * 특정 카테고리 ID와 (선택적) 난이도 조건에 맞는 퀴즈를 무작위로 조회하되,
+	 * 주어진 퀴즈 ID 목록에서만 선택합니다.
+	 * @param categoryId 카테고리 ID
+	 * @param level 난이도 (null일 경우 모든 난이도 포함)
+	 * @param includeIds 포함할 퀴즈 ID 목록 (빈 리스트 가능)
+	 * @param pageable 페이지 정보 (예: PageRequest.of(0, 5) - 첫 페이지, 5개 항목)
+	 * @return 퀴즈 목록
+	 */
+	@Query("""
+    select q from QuizJpaEntity q
+    where q.categoryId = :categoryId
+      and (:level is null or q.level = :level)
+      and q.quizId in :includeIds
+    order by function('rand')
+""")
+	List<QuizJpaEntity> pickByIncludeIds(Long categoryId, QuizLevel level, List<Long> includeIds, Pageable pageable);
+
+	/**
+	 * 특정 카테고리 ID와 (선택적) 난이도 조건에 맞는 퀴즈를 무작위로 조회하되,
+	 * 주어진 퀴즈 ID 목록은 제외합니다.
+	 * @param categoryId 카테고리 ID
+	 * @param level 난이도 (null일 경우 모든 난이도 포함)
+	 * @param excludedIds 제외할 퀴즈 ID 목록 (빈 리스트 가능)
+	 * @param pageable 페이지 정보 (예: PageRequest.of(0, 5) - 첫 페이지, 5개 항목)
+	 * @return 퀴즈 목록
+	 */
+	@Query("""
+    select q from QuizJpaEntity q
+    where q.categoryId = :categoryId
+      and (:level is null or q.level = :level)
+      and q.quizId not in :excludedIds
+    order by function('rand')
+""")
+	List<QuizJpaEntity> pickFillRandomExcluding(Long categoryId, QuizLevel level, List<Long> excludedIds, Pageable pageable);
 }

--- a/src/main/java/com/grow/notification_service/quiz/infra/persistence/repository/QuizRepositoryImpl.java
+++ b/src/main/java/com/grow/notification_service/quiz/infra/persistence/repository/QuizRepositoryImpl.java
@@ -75,4 +75,40 @@ public class QuizRepositoryImpl implements QuizRepository {
 		}
 		return rows.stream().map(mapper::toDomain).toList();
 	}
+
+	/**
+	 * 특정 퀴즈 ID 목록에서 무작위로 퀴즈 선택
+	 * @param categoryId 카테고리 ID
+	 * @param level 난이도 (null이면 모든 난이도)
+	 * @param includeIds 포함할 퀴즈 ID 목록 (null 또는 빈 리스트이면 빈 리스트 반환)
+	 * @param pageable 페이지 정보 (예: PageRequest.of(0, 5) - 첫 페이지, 5개 항목)
+	 * @return 퀴즈 도메인 객체 목록
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Quiz> pickFromIncludeIds(Long categoryId, QuizLevel level, List<Long> includeIds, Pageable pageable) {
+		if (includeIds == null || includeIds.isEmpty()) return List.of();
+		return jpa.pickByIncludeIds(categoryId, level, includeIds, pageable)
+			.stream()
+			.map(mapper::toDomain)
+			.toList();
+	}
+
+	/**
+	 * 특정 카테고리와 난이도에서, 제외할 퀴즈 ID 목록을 제외하고 무작위로 퀴즈 선택
+	 * @param categoryId 카테고리 ID
+	 * @param level 난이도 (null이면 모든 난이도)
+	 * @param excludedIds 제외할 퀴즈 ID 목록 (null 또는 빈 리스트 가능)
+	 * @param pageable 페이지 정보 (예: PageRequest.of(0, 5) - 첫 페이지, 5개 항목)
+	 * @return 퀴즈 도메인 객체 목록
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Quiz> pickFillRandomExcluding(Long categoryId, QuizLevel level, List<Long> excludedIds, Pageable pageable) {
+		List<Long> excluded = (excludedIds == null) ? List.of() : excludedIds;
+		return jpa.pickFillRandomExcluding(categoryId, level, excluded, pageable)
+			.stream()
+			.map(mapper::toDomain)
+			.toList();
+	}
 }

--- a/src/main/java/com/grow/notification_service/quiz/presentation/controller/QuizController.java
+++ b/src/main/java/com/grow/notification_service/quiz/presentation/controller/QuizController.java
@@ -44,6 +44,19 @@ public class QuizController {
 		);
 	}
 
+	@GetMapping("/review")
+	public RsData<List<QuizItem>> pickReview(
+		@RequestHeader("X-Authorization-Id") Long memberId,
+		@RequestParam String skillTag,
+		@RequestParam String mode,
+		@RequestParam(required = false) Integer total,
+		@RequestParam(required = false) Double wrongRatio
+	) {
+		List<QuizItem> data = appService.pickReviewByHistory(memberId, skillTag, mode, total, wrongRatio);
+
+		return new RsData<>("200", "혼합 출제(틀린 문제 우선) 조회 완료", data);
+	}
+
 	/**
 	 * 퀴즈 정답 제출
 	 * @param memberId - X-Authorization-Id

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -17,3 +17,4 @@ invalid.skill.tag=유효하지 않은 스킬 태그입니다.
 unsupported.mode=지원하지 않는 모드입니다.
 quiz.not.found=해당 퀴즈를 찾을 수 없습니다.
 category.mismatch=카테고리가 일치하지 않습니다.
+not.enough.history=복습은 최소 5문제의 퀴즈를 푼 뒤 가능합니다.

--- a/src/test/java/com/grow/notification_service/quiz/domain/service/QuizReviewServiceTest.java
+++ b/src/test/java/com/grow/notification_service/quiz/domain/service/QuizReviewServiceTest.java
@@ -1,0 +1,141 @@
+package com.grow.notification_service.quiz.domain.service;
+
+import com.grow.notification_service.quiz.domain.model.Quiz;
+import com.grow.notification_service.quiz.infra.persistence.enums.QuizLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QuizReviewServiceTest {
+
+	private final QuizReviewService service = new QuizReviewService();
+
+	private Quiz makeQuiz(Long id) {
+		return new Quiz(
+			id,
+			"Q" + id,
+			List.of("A", "B", "C"),
+			"A",
+			"exp",
+			QuizLevel.EASY,
+			10L
+		);
+	}
+
+	@Nested
+	@DisplayName("hasEnoughHistory")
+	class HasEnoughHistory {
+
+		@Test
+		@DisplayName("null 이력이면 false")
+		void null_history() {
+			assertFalse(service.hasEnoughHistory(null));
+		}
+
+		@Test
+		@DisplayName("빈 리스트면 false")
+		void empty_history() {
+			assertFalse(service.hasEnoughHistory(List.of()));
+		}
+
+		@Test
+		@DisplayName("4개 이력이면 false (MIN_HISTORY=5 미만)")
+		void four_items_false() {
+			List<Quiz> history = List.of(
+				makeQuiz(1L), makeQuiz(2L), makeQuiz(3L), makeQuiz(4L)
+			);
+			assertFalse(service.hasEnoughHistory(history));
+		}
+
+		@Test
+		@DisplayName("5개 이력이면 true (임계값 충족)")
+		void five_items_true() {
+			List<Quiz> history = List.of(
+				makeQuiz(1L), makeQuiz(2L), makeQuiz(3L), makeQuiz(4L), makeQuiz(5L)
+			);
+			assertTrue(service.hasEnoughHistory(history));
+		}
+
+		@Test
+		@DisplayName("6개 이상이면 true")
+		void six_plus_true() {
+			List<Quiz> history = List.of(
+				makeQuiz(1L), makeQuiz(2L), makeQuiz(3L), makeQuiz(4L), makeQuiz(5L), makeQuiz(6L)
+			);
+			assertTrue(service.hasEnoughHistory(history));
+		}
+	}
+
+	@Nested
+	@DisplayName("computeNeeds")
+	class ComputeNeeds {
+
+		@Test
+		@DisplayName("total<=0 이면 DEFAULT_TOTAL(5), wrongRatio=null 이면 DEFAULT_WRONG_RATIO(0.6)")
+		void defaults_applied() {
+			QuizReviewService.Need need = service.computeNeeds(0, null);
+			// total = 5, wrongRatio = 0.6 → wrong = ceil(3.0) = 3, correct = 2
+			assertEquals(3, need.wrong());
+			assertEquals(2, need.correct());
+			assertEquals(5, need.wrong() + need.correct());
+		}
+
+		@Test
+		@DisplayName("wrongRatio가 0.6일 때 total=10 → wrong=6, correct=4")
+		void ratio_point_six_total_ten() {
+			QuizReviewService.Need need = service.computeNeeds(10, 0.6);
+			assertEquals(6, need.wrong());
+			assertEquals(4, need.correct());
+			assertEquals(10, need.wrong() + need.correct());
+		}
+
+		@Test
+		@DisplayName("wrongRatio=0.5에서 올림 적용: total=7 → wrong=ceil(3.5)=4, correct=3")
+		void ceiling_applied() {
+			QuizReviewService.Need need = service.computeNeeds(7, 0.5);
+			assertEquals(4, need.wrong());
+			assertEquals(3, need.correct());
+			assertEquals(7, need.wrong() + need.correct());
+		}
+
+		@Test
+		@DisplayName("wrongRatio 경계값(<=0 또는 >=1)은 기본값(0.6)으로 대체")
+		void out_of_range_ratio_uses_default() {
+			// <= 0.0
+			QuizReviewService.Need n1 = service.computeNeeds(5, 0.0);
+			assertEquals(3, n1.wrong()); // default 0.6 → ceil(3)
+			assertEquals(2, n1.correct());
+
+			// >= 1.0
+			QuizReviewService.Need n2 = service.computeNeeds(5, 1.0);
+			assertEquals(3, n2.wrong()); // 역시 default로 처리
+			assertEquals(2, n2.correct());
+		}
+
+		@Test
+		@DisplayName("wrongNeed는 total을 넘지 않음, correctNeed는 음수가 되지 않음")
+		void bounds_sanity() {
+			QuizReviewService.Need need = service.computeNeeds(3, 0.99); // 유효 범위 → ceil(2.97)=3
+			assertEquals(3, need.wrong());
+			assertEquals(0, need.correct());
+			assertEquals(3, need.wrong() + need.correct());
+		}
+
+		@Test
+		@DisplayName("총합은 항상 total과 동일")
+		void sum_matches_total() {
+			QuizReviewService.Need n1 = service.computeNeeds(8, 0.25); // ceil(2) = 2
+			assertEquals(8, n1.wrong() + n1.correct());
+
+			QuizReviewService.Need n2 = service.computeNeeds(9, 0.33); // ceil(2.97)=3
+			assertEquals(9, n2.wrong() + n2.correct());
+
+			QuizReviewService.Need n3 = service.computeNeeds(1, 0.9); // ceil(0.9)=1
+			assertEquals(1, n3.wrong() + n3.correct());
+		}
+	}
+}


### PR DESCRIPTION
## 🔍 Title(필수)
#36 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

### 문제 출제
<img width="885" height="1250" alt="스크린샷 2025-09-13 214309" src="https://github.com/user-attachments/assets/a9f53324-104f-4875-a3cd-cc42b1080fb5" />

### 복습 문제 출제에 필요한 문제 수가 부족한 경우
<img width="882" height="906" alt="스크린샷 2025-09-13 214255" src="https://github.com/user-attachments/assets/f895c851-dd29-4109-be62-427c205ba471" />

## 🔗 Related Issues(필수)
Closes #36

## 📝 Note (주의 사항)
문제 풀이 이력이 5개 이상일 경우, 그것을 기반으로 복습 문제를 출제해주는 api를 구현했습니다.
1. 멤버의 카테고리별 정답/오답 문제 id 조회, 최소 이력(기본 5개)이 없으면 복습 출제 x
2. 정답+오답 id 합집합으로 카테고리 내 문제 풀이 이력 개수 확인, 5개 이상이여야 복습 출제 진행
3. 출제 수 계산 -> 기본값: 5문제, 틀린 문제 비율 0.6 -> 오답 3, 정답 2문제 출제
4. 틀린 문제에서 먼저 랜덤 출제, 부족분은 정답 맞춘 문제에서 보충, 그래도 부족하면 카테고리 전체 랜덤 보충

간단하게 만들어보앗습니다.. 첨언 환영

