### PR TITLE
✨ feat: 퀴즈 생성 기능 추가 (카테고리 지정 5문제, 틀린 문제 기반 5문제)

### DIFF
--- a/src/main/java/com/grow/notification_service/analysis/application/prompt/QuizPrompt.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/prompt/QuizPrompt.java
@@ -1,0 +1,121 @@
+package com.grow.notification_service.analysis.application.prompt;
+
+import lombok.Getter;
+
+@Getter
+public enum QuizPrompt {
+	GENERATE("""
+역할: 너는 GROW의 퀴즈 출제기다.
+목표: 입력 조건에 맞는 5문제 객관식 퀴즈를 '유효한 JSON 배열'로만 반환한다. 마크다운/설명/주석 금지.
+
+출력 형식(절대 위반 금지):
+- 출력은 오직 JSON 배열 하나여야 한다. 앞/뒤/사이에 기타 텍스트 금지.
+- JSON은 표준 쌍따옴표(\")만 사용한다. 스마트 따옴표(‘ ’ “ ”) 금지.
+- 문자열 내부의 역슬래시(\\)와 쌍따옴표는 반드시 JSON 규칙대로 이스케이프한다(예: \\\\ , \\").
+- 줄바꿈/탭/제어문자는 반드시 \\n, \\t, \\u0000 형태로 작성한다. 원문 제어문자 삽입 금지.
+- 배열/객체의 끝에 trailing comma 금지.
+- choices와 answer 문자열에는 ' 또는 " 자체 문자를 넣지 않는다. 필요한 경우 설명형으로 표현한다.
+  (예: 문자 리터럴 '\0' 대신 "널 문자(\\u0000)"처럼 설명형으로 작성)
+
+입력 변수:
+- categoryId: <number>
+- skillTagCode: <string> // 예: DATABASE_MANAGEMENT, JAVA_PROGRAMMING
+- level: EASY|NORMAL|HARD|RANDOM
+- topic: string | '제한 없음'
+- count: 5
+
+출력 스키마(반드시 준수):
+[
+  {
+    "question": "string",
+    "choices": ["string","string","string","string"],
+    "answer": "string",
+    "explain": "string",
+    "level": "EASY|NORMAL|HARD",
+    "categoryId": <number>
+  }
+]
+
+제약:
+- 항상 정확히 5문제.
+- choices는 정확히 4개.
+- answer는 choices 중 하나와 **문자열이 완전히 동일**해야 한다(앞뒤 공백/마침표/조사 금지).
+- question은 한 문장, 60자 이내. 불필요한 수식어·중복 금지.
+- explain은 1~2문장, 120자 이내. 핵심 근거만 간결히.
+- choices 각 항목은 8~30자, 서로 의미 중복/동의어 금지.
+- level이 RANDOM이면 EASY/NORMAL/HARD 혼합. 특정 레벨이면 전부 그 레벨.
+- topic과 skillTagCode 범위를 벗어나지 말 것.
+- 한국어 자연스럽게. 문제-보기-정답-해설 간 모호성/중복 금지.
+- categoryId는 입력 categoryId와 동일하게 채워 넣을 것.
+
+금지/치환 규칙(중요):
+- 따옴표/백슬래시가 필요한 프로그래밍 리터럴을 **그대로** 쓰지 말고, 설명형으로 치환하라.
+  예) "'A'" → "문자 A"
+      "'\\n'" → "줄바꿈 문자(\\n)"
+      "'\\0'" → "널 문자(\\u0000)"
+- null/undefined/빈 문자열/제어문자 원문 삽입 금지(설명형으로).
+
+품질 가이드:
+- 문제는 서로 다른 개념/상황을 다룬다.
+- 해설은 왜 오답/정답인지 핵심 근거 포함, 1~2문장.
+"""),
+
+	GENERATE_FROM_WRONG("""
+역할: 너는 GROW의 퀴즈 출제기다.
+목표: 입력 '오답 아이템들(JSON)'을 기반으로, 같은 개념군을 다루되 중복되지 않는 5문제 객관식 퀴즈를
+'유효한 JSON 배열'로만 반환한다. (마크다운/설명/주석 금지)
+
+출력 형식(절대 위반 금지):
+- 출력은 오직 JSON 배열 하나여야 한다. 앞/뒤/사이에 기타 텍스트 금지.
+- JSON은 표준 쌍따옴표(\")만 사용한다. 스마트 따옴표 금지.
+- 문자열 내부의 역슬래시(\\)와 쌍따옴표는 반드시 JSON 규칙대로 이스케이프한다(예: \\\\ , \\").
+- 줄바꿈/탭/제어문자는 반드시 \\n, \\t, \\u0000 형태로 작성한다. 원문 제어문자 삽입 금지.
+- 배열/객체의 끝에 trailing comma 금지.
+- choices와 answer 문자열에는 ' 또는 " 자체 문자를 넣지 않는다. 필요한 경우 설명형으로 표현한다.
+  (예: 문자 리터럴 '\0' 대신 "널 문자(\\u0000)")
+
+입력 변수:
+- categoryId: <number>
+- level: EASY|NORMAL|HARD|RANDOM
+- topic: string | '제한 없음'
+- items: 오답 문항 요약 JSON (question/choices/correctAnswer/explain 포함)
+
+출력 스키마:
+[
+  {
+    "question": "string",
+    "choices": ["string","string","string","string"],
+    "answer": "string",
+    "explain": "string",
+    "level": "EASY|NORMAL|HARD",
+    "categoryId": <number>
+  }
+]
+
+제약:
+- 항상 정확히 5문제.
+- choices는 정확히 4개.
+- answer는 choices 중 하나와 **문자열이 완전히 동일**해야 한다.
+- question은 한 문장, 60자 이내.
+- explain은 1~2문장, 120자 이내.
+- choices 각 항목은 8~30자, 서로 의미 중복/동의어 금지.
+- level이 RANDOM이면 EASY/NORMAL/HARD 혼합. 특정 레벨이면 전부 그 레벨.
+- topic/입력 items의 개념군을 벗어나지 말 것.
+- 한국어 자연스럽게. 모호성/중복 금지.
+- categoryId는 입력 categoryId로 채울 것.
+
+금지/치환 규칙(중요):
+- 따옴표/백슬래시가 필요한 프로그래밍 리터럴을 **그대로** 쓰지 말고, 설명형으로 치환하라.
+  예) "'\"'" → '쌍따옴표 문자' 라고 쓰지 말고 → "쌍따옴표 문자"
+      "'\\n'" → "줄바꿈 문자(\\n)"
+      "'\\0'" → "널 문자(\\u0000)"
+- null/undefined/빈 문자열/제어문자 원문 삽입 금지(설명형으로).
+
+품질 가이드:
+- 기존 오답의 개념을 변주하여 '비슷하지만 다른 상황'을 제시.
+- 해설은 왜 오답/정답인지 핵심 근거 포함, 1~2문장.
+""");
+
+	private final String system;
+	QuizPrompt(String system) { this.system = system; }
+}

--- a/src/main/java/com/grow/notification_service/analysis/application/service/QuizGenerationApplicationService.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/QuizGenerationApplicationService.java
@@ -1,0 +1,10 @@
+package com.grow.notification_service.analysis.application.service;
+
+import java.util.List;
+
+import com.grow.notification_service.quiz.domain.model.Quiz;
+
+public interface QuizGenerationApplicationService {
+	List<Quiz> generateAndSave(Long memberId, Long categoryId, String levelParam, String topic);
+	List<Quiz> generateQuizzesFromWrong(Long memberId, Long categoryId, String levelParam, String topic);
+}

--- a/src/main/java/com/grow/notification_service/analysis/application/service/impl/QuizGenerationApplicationServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/impl/QuizGenerationApplicationServiceImpl.java
@@ -1,0 +1,442 @@
+package com.grow.notification_service.analysis.application.service.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.grow.notification_service.analysis.application.port.LlmClientPort;
+import com.grow.notification_service.analysis.application.prompt.QuizPrompt;
+import com.grow.notification_service.analysis.application.service.QuizGenerationApplicationService;
+import com.grow.notification_service.global.exception.AnalysisException;
+import com.grow.notification_service.global.exception.ErrorCode;
+import com.grow.notification_service.quiz.application.MemberQuizResultPort;
+import com.grow.notification_service.quiz.application.mapping.SkillTagToCategoryRegistry;
+import com.grow.notification_service.quiz.domain.model.Quiz;
+import com.grow.notification_service.quiz.domain.repository.QuizRepository;
+import com.grow.notification_service.quiz.infra.persistence.enums.QuizLevel;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuizGenerationApplicationServiceImpl implements QuizGenerationApplicationService {
+
+	private final LlmClientPort llm;
+	private final QuizRepository quizRepository;
+	private final ObjectMapper mapper;
+	private final SkillTagToCategoryRegistry skillTagToCategoryRegistry;
+	private final MemberQuizResultPort memberQuizResultPort;
+
+	/**
+	 * LLM으로 5문제 생성 -> 파싱 -> 저장 후 반환
+	 * @param memberId 호출자(로그 용도)
+	 * @param categoryId 카테고리
+	 * @param levelParam EASY|NORMAL|HARD|RANDOM (대소문자 무시)
+	 * @param topic 주제(옵션)
+	 */
+	@Override
+	@Transactional
+	public List<Quiz> generateAndSave(Long memberId, Long categoryId, String levelParam, String topic) {
+		boolean randomMode = isRandom(levelParam);
+		QuizLevel forcedLevel = randomMode ? null : parseLevelOrNull(levelParam);
+
+		String skillTagCode = skillTagToCategoryRegistry.toSkillTagOrThrow(categoryId);
+
+		log.info("[QUIZ][GEN][START] memberId={}, categoryId={}, levelParam={}, topic={}",
+			memberId, categoryId, levelParam, topic);
+
+		try {
+			// LLM 호출
+			String system = QuizPrompt.GENERATE.getSystem();
+			String user = buildUserPrompt(categoryId, levelParam, topic, skillTagCode);
+			log.debug("[QUIZ][GEN][PROMPT] system={}, user={}", system, user);
+
+			String json = llm.generateJson(system, user);
+			log.info("[QUIZ][GEN][LLM] 호출 완료");
+
+			// 파싱
+			List<Quiz> parsed = parseQuizzes(json, categoryId, forcedLevel, randomMode);
+			log.info("[QUIZ][GEN][PARSE] parsedCount={}", parsed.size());
+
+			// 저장
+			List<Quiz> saved = new ArrayList<>(parsed.size());
+			for (Quiz q : parsed) {
+				saved.add(quizRepository.save(q));
+			}
+			log.info("[QUIZ][GEN][END] 저장 완료 - saved={}", saved.size());
+			return saved;
+
+		} catch (AnalysisException ae) {
+			throw ae;
+		} catch (Exception e) {
+			log.error("[QUIZ][GEN] 처리 실패 - memberId={}, categoryId={}, err={}", memberId, categoryId, e.toString(), e);
+			throw new AnalysisException(ErrorCode.ANALYSIS_UNEXPECTED_FAILED, e);
+		}
+	}
+
+	/**
+	 * 틀린 문제 기반 퀴즈 생성 + 저장
+	 * @param memberId 멤버ID
+	 * @param categoryId 카테고리ID
+	 * @param levelParam EASY|NORMAL|HARD|RANDOM
+	 * @param topic 주제 (사용자가 입력 가능, 빈 값 허용)
+	 * @return 생성된 퀴즈 목록 (최대 5개)
+	 */
+	@Override
+	@Transactional
+	public List<Quiz> generateQuizzesFromWrong(Long memberId, Long categoryId, String levelParam, String topic) {
+		log.info("[QUIZ][GEN][FROM_WRONG][START] memberId={}, categoryId={}, levelParam={}, topic={}",
+			memberId, categoryId, levelParam, topic);
+
+		// 1) 오답 수집
+		List<Long> wrongIds = memberQuizResultPort.findAnsweredQuizIds(memberId, categoryId, Boolean.FALSE);
+		if (wrongIds == null) wrongIds = List.of();
+		List<Quiz> wrongQuizzes = wrongIds.isEmpty() ? List.of() : quizRepository.findByIds(wrongIds);
+		Map<Long, Quiz> byId = wrongQuizzes.stream().collect(Collectors.toMap(Quiz::getQuizId, q -> q));
+
+		// 카테고리 필터링
+		if (categoryId != null) {
+			wrongIds = wrongIds.stream()
+				.filter(id -> byId.containsKey(id) && categoryId.equals(byId.get(id).getCategoryId()))
+				.toList();
+		}
+		log.info("[QUIZ][GEN][FROM_WRONG] 컨텍스트 준비 - wrongIds={}, filteredSize={}", wrongIds.size(), wrongIds.size());
+
+		// 2) 입력 payload 구성
+		String itemsJson = buildItemsJson(byId, wrongIds);
+		boolean randomMode = isRandom(levelParam);
+		QuizLevel forcedLevel = randomMode ? null : parseLevelOrNull(levelParam);
+
+		// 3) LLM 호출
+		String system = QuizPrompt.GENERATE_FROM_WRONG.getSystem();
+		String user = buildQuizFromWrongUserPrompt(itemsJson, categoryId, levelParam, topic);
+		log.debug("[QUIZ][GEN][FROM_WRONG][PROMPT] system={}, user={}", system, user);
+
+		String json = llm.generateJson(system, user);
+		log.info("[QUIZ][GEN][FROM_WRONG][LLM] 호출 완료");
+
+		// 4) 파싱/검증/중복제거
+		List<Quiz> parsed = parseGeneratedQuizzes(json, categoryId, forcedLevel, randomMode);
+		log.info("[QUIZ][GEN][FROM_WRONG][PARSE] parsedCount={}", parsed.size());
+
+		// 세션 내 중복 제거 + DB 중복 제거
+		List<Quiz> filtered = new ArrayList<>(5);
+		Set<String> seen = new HashSet<>();
+		for (Quiz q : parsed) {
+			String norm = q.getQuestion().trim().replaceAll("\\s+"," ").toLowerCase();
+			if (!seen.add(norm)) {
+				log.info("[QUIZ][GEN][FROM_WRONG] 세션 중복 스킵 - q='{}'", q.getQuestion());
+				continue;
+			}
+			if (quizRepository.existsByCategoryIdAndQuestion(categoryId, q.getQuestion())) {
+				log.info("[QUIZ][GEN][FROM_WRONG] DB 중복 스킵 - q='{}'", q.getQuestion());
+				continue;
+			}
+			filtered.add(q);
+		}
+
+		// 5) 저장
+		List<Quiz> saved = new ArrayList<>(filtered.size());
+		for (Quiz q : filtered) {
+			saved.add(quizRepository.save(q));
+		}
+		log.info("[QUIZ][GEN][FROM_WRONG][END] 저장 완료 - requested=5, saved={}", saved.size());
+		return saved;
+	}
+
+	// 헬퍼 메서드
+
+	/**
+	 * LLM 프롬프트 생성
+	 * @param categoryId 카테고리
+	 * @param levelParam EASY|NORMAL|HARD|RANDOM
+	 * @param topic 주제
+	 * @param skillTagCode 스킬태그 코드
+	 * @return 프롬프트 문자열
+	 */
+	private String buildUserPrompt(Long categoryId, String levelParam, String topic, String skillTagCode) {
+		String lv = (levelParam == null || levelParam.isBlank()) ? "RANDOM" : levelParam.trim().toUpperCase();
+		String tp = (topic == null || topic.isBlank()) ? "제한 없음" : topic.trim();
+		return """
+입력:
+- categoryId: %d
+- skillTagCode: %s
+- 난이도: %s
+- 문제 수: 5
+- 주제: %s
+
+요청:
+- 위 입력을 반영해 스키마에 맞춘 '유효한 JSON 배열'만 반환하라.
+""".formatted(categoryId, skillTagCode, lv, tp);
+	}
+
+	/**
+	 * LLM 응답 파싱
+	 * @param json LLM 응답 JSON 문자열
+	 * @param categoryId 카테고리
+	 * @param forcedLevel EASY|NORMAL|HARD (RANDOM 모드가 아닐 때만 유효)
+	 * @param randomMode RANDOM 모드 여부
+	 * @return 파싱된 Quiz 리스트(항상 5개)
+	 */
+	private List<Quiz> parseQuizzes(String json, Long categoryId, QuizLevel forcedLevel, boolean randomMode) {
+		try {
+			JsonNode root = mapper.readTree(json);
+			// 배열/크기 검사
+			if (!root.isArray()) {
+				throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+			}
+			ArrayNode arr = (ArrayNode) root;
+			// 5문제 검사
+			if (arr.size() != 5) {
+				throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+			}
+
+			// 각 항목 검사 및 파싱
+			List<Quiz> out = new ArrayList<>(5);
+			for (JsonNode n : arr) {
+				String question = textReq(n, "question");
+				List<String> choices = readChoices(n);
+				String answer = textReq(n, "answer");
+				String explain = textReq(n, "explain");
+
+				// 제약 조건 검사
+				if (!choices.contains(answer)) {
+					throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+				}
+
+				QuizLevel level;
+				if (randomMode) {
+					level = parseLevelOrNull(n.has("level") ? n.get("level").asText("") : null);
+					if (level == null) {
+						throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+					}
+				} else {
+					level = forcedLevel; // EASY/NORMAL/HARD로 강제
+				}
+
+				out.add(Quiz.create(question, choices, answer, explain, level, categoryId));
+			}
+			return out;
+
+		} catch (AnalysisException ae) {
+			throw ae;
+		} catch (Exception e) {
+			log.error("[QUIZ][GEN][PARSE] 실패 - err={}", e.toString(), e);
+			throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED, e);
+		}
+	}
+
+	/**
+	 * 생성된 퀴즈 파싱
+	 * @param json LLM 응답 JSON 문자열
+	 * @param categoryId 카테고리
+	 * @param forcedLevel EASY|NORMAL|HARD (RANDOM 모드가 아닐 때만 유효)
+	 * @param randomMode RANDOM 모드 여부
+	 * @return 파싱된 Quiz 리스트(항상 5개)
+	 */
+	private List<Quiz> parseGeneratedQuizzes(String json, Long categoryId, QuizLevel forcedLevel, boolean randomMode) {
+		try {
+			JsonNode root = mapper.readTree(json); // objectMapper → mapper로 통일
+			// 배열/크기 검사
+			if (!root.isArray()) {
+				throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+			}
+			ArrayNode arr = (ArrayNode) root;
+			// 5문제 검사
+			if (arr.size() != 5) {
+				throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+			}
+			List<Quiz> out = new ArrayList<>(5);
+			// 각 항목 검사 및 파싱
+			for (JsonNode n : arr) {
+				long catFromLlm = longReq(n, "categoryId");
+				if (catFromLlm != categoryId) {
+					throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+				}
+				String question = textReq(n, "question");
+				List<String> choices = readChoices(n);
+				String answer = textReq(n, "answer");
+				String explain = textReq(n, "explain");
+
+				if (!choices.contains(answer))
+					// 정답이 선택지에 포함되어야 함
+					throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+
+				QuizLevel level;
+				if (randomMode) {
+					level = parseLevelOrNull(n.has("level") ? n.get("level").asText("") : null);
+					if (level == null) {
+						throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED);
+					}
+				} else {
+					level = forcedLevel; // EASY/NORMAL/HARD로 강제
+				}
+
+				out.add(Quiz.create(question, choices, answer, explain, level, categoryId));
+			}
+			return out;
+
+		} catch (AnalysisException ae) {
+			throw ae;
+		} catch (Exception e) {
+			log.error("[QUIZ][GEN][FROM_WRONG][PARSE] 실패 - err={}", e.toString(), e);
+			throw new AnalysisException(ErrorCode.ANALYSIS_QUIZ_GENERATION_PARSE_FAILED, e);
+		}
+	}
+
+	/**
+	 * 필수 텍스트 필드 읽기
+	 * @param n JSON 노드
+	 * @param field 필드명
+	 * @return 읽은 값
+	 */
+	private String textReq(JsonNode n, String field) {
+		// 필수/빈값 검사
+		if (!n.hasNonNull(field)) {
+			throw new AnalysisException(ErrorCode.ANALYSIS_REQUIRED_FIELD_MISSING);
+		}
+		String v = n.get(field).asText("");
+		// 빈값 검사
+		if (v.isBlank()) {
+			throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE);
+		}
+		return v;
+	}
+
+	/**
+	 * choices 필드 읽기
+	 * @param n JSON 노드
+	 * @return 읽은 값 리스트
+	 */
+	private List<String> readChoices(JsonNode n) {
+		// 필수/형식/크기 검사
+		if (!n.has("choices") || !n.get("choices").isArray()) {
+			throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE);
+		}
+		// 4개 검사
+		ArrayNode ca = (ArrayNode) n.get("choices");
+		if (ca.size() != 4) {
+			throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE);
+		}
+		// 각 항목 빈값 검사
+		List<String> list = new ArrayList<>(4);
+		for (JsonNode c : ca) {
+			String s = c.asText("");
+			if (s.isBlank()) throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE);
+			list.add(s);
+		}
+		return list;
+	}
+
+	/**
+	 * 필수 long 필드 읽기
+	 * @param n JSON 노드
+	 * @param field 필드명
+	 * @return 읽은 값
+	 */
+	private long longReq(JsonNode n, String field) {
+		if (!n.hasNonNull(field)) {
+			throw new AnalysisException(ErrorCode.ANALYSIS_REQUIRED_FIELD_MISSING);
+		}
+		JsonNode v = n.get(field);
+		if (v.isIntegralNumber()) return v.asLong();
+		if (v.isTextual()) {
+			try {
+				return Long.parseLong(v.asText().trim());
+			} catch (NumberFormatException ex) {
+				throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE, ex);
+			}
+		}
+		throw new AnalysisException(ErrorCode.ANALYSIS_INVALID_FIELD_VALUE);
+	}
+
+	/**
+	 * RANDOM 모드 여부 판단
+	 * @param levelParam EASY|NORMAL|HARD|RANDOM|null|빈문자열
+	 * @return RANDOM 모드 여부
+	 */
+	private boolean isRandom(String levelParam) {
+		return levelParam == null || levelParam.isBlank() || "RANDOM".equalsIgnoreCase(levelParam.trim());
+	}
+
+	/**
+	 * EASY|NORMAL|HARD 파싱
+	 * @param v 파싱할 문자열
+	 * @return 파싱된 QuizLevel, 알 수 없는 값이면 null 반환
+	 */
+	private QuizLevel parseLevelOrNull(String v) {
+		if (v == null) return null;
+		return switch (v.trim().toUpperCase()) {
+			case "EASY" -> QuizLevel.EASY;
+			case "NORMAL" -> QuizLevel.NORMAL;
+			case "HARD" -> QuizLevel.HARD;
+			default -> null;
+		};
+	}
+
+	/**
+	 * 틀린 문제 기반 퀴즈 생성용 유저 프롬프트 구성
+	 * @param itemsJson LLM 입력 JSON
+	 * @param categoryId 카테고리ID
+	 * @param levelParam EASY|NORMAL|HARD|RANDOM|null|빈문자열
+	 * @param topic 주제 (사용자가 입력 가능, 빈 값 허용)
+	 * @return 유저 프롬프트
+	 */
+	private String buildQuizFromWrongUserPrompt(String itemsJson, Long categoryId, String levelParam, String topic) {
+		String lv = (levelParam == null || levelParam.isBlank()) ? "RANDOM" : levelParam.trim().toUpperCase();
+		String tp = (topic == null || topic.isBlank()) ? "제한 없음" : topic.trim();
+		return """
+입력:
+- categoryId: %d
+- level: %s
+- count: 5
+- topic: %s
+- items(JSON): %s
+
+요청:
+- 위 입력을 반영해 [출력 스키마]에 정확히 맞는 '유효한 JSON 배열'만 반환하라.
+""".formatted(categoryId, lv, tp, itemsJson);
+	}
+
+	/**
+	 * LLM 입력용 JSON 구성
+	 * @param byId 퀴즈 ID 맵
+	 * @param wrongIds 오답 퀴즈 ID 목록
+	 * @return 직렬화된 JSON 문자열
+	 */
+	private String buildItemsJson(Map<Long, Quiz> byId, List<Long> wrongIds) {
+		try {
+			List<Map<String, Object>> items = new ArrayList<>();
+			for (Long qid : wrongIds) {
+				Quiz q = byId.get(qid);
+				if (q == null)
+					continue;
+				Map<String, Object> one = new LinkedHashMap<>();
+				one.put("quizId", q.getQuizId());
+				one.put("question", q.getQuestion());
+				one.put("choices", q.getChoices());
+				one.put("correctAnswer", q.getAnswer());
+				one.put("explain", q.getExplain());
+				items.add(one);
+			}
+			Map<String, Object> llmInput = new LinkedHashMap<>();
+			llmInput.put("items", items);
+			return mapper.writeValueAsString(llmInput);
+		} catch (Exception ex) {
+			log.error("[ANALYSIS][FOCUS] LLM 입력 직렬화 실패 - wrongIds={}, err={}", wrongIds, ex, ex);
+			throw new AnalysisException(ErrorCode.ANALYSIS_INPUT_SERIALIZE_FAILED, ex);
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/analysis/presentation/controller/AnalysisController.java
+++ b/src/main/java/com/grow/notification_service/analysis/presentation/controller/AnalysisController.java
@@ -1,5 +1,7 @@
 package com.grow.notification_service.analysis.presentation.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,8 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.grow.notification_service.analysis.application.service.AnalysisApplicationService;
+import com.grow.notification_service.analysis.application.service.QuizGenerationApplicationService;
 import com.grow.notification_service.analysis.domain.model.Analysis;
 import com.grow.notification_service.analysis.presentation.controller.dto.AnalysisResponse;
+import com.grow.notification_service.analysis.presentation.controller.dto.QuizResponse;
+import com.grow.notification_service.quiz.domain.model.Quiz;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class AnalysisController {
 
 	private final AnalysisApplicationService service;
+	private final QuizGenerationApplicationService quizService;
 	private final ObjectMapper objectMapper;
 
 	/**
@@ -43,5 +49,34 @@ public class AnalysisController {
 	) {
 		Analysis analysis = service.analyzeQuiz(memberId, categoryId);
 		return AnalysisResponse.from(analysis, objectMapper);
+	}
+
+	/**
+	 * 카테고리, 난이도 별 5문제 생성
+	 */
+	@PostMapping("/generate")
+	public List<Quiz> generate(
+		@RequestHeader("X-Authorization-Id") Long memberId,
+		@RequestParam Long categoryId,
+		@RequestParam(defaultValue = "RANDOM") String level,
+		@RequestParam(required = false) String topic
+	) {
+		return quizService.generateAndSave(memberId, categoryId, level, topic);
+	}
+
+	/**
+	 * 틀린 문제 기반 퀴즈 생성(5문항) + 저장 후 반환
+	 * level: EASY | NORMAL | HARD | RANDOM (기본 RANDOM)
+	 * topic: 선택
+	 */
+	@PostMapping("/generate-from-wrong")
+	public List<QuizResponse> generateFromWrong(
+		@RequestHeader("X-Authorization-Id") Long memberId,
+		@RequestParam Long categoryId,
+		@RequestParam(defaultValue = "RANDOM") String level,
+		@RequestParam(required = false) String topic
+	) {
+		List<Quiz> created = quizService.generateQuizzesFromWrong(memberId, categoryId, level, topic);
+		return created.stream().map(QuizResponse::from).toList();
 	}
 }

--- a/src/main/java/com/grow/notification_service/analysis/presentation/controller/dto/QuizResponse.java
+++ b/src/main/java/com/grow/notification_service/analysis/presentation/controller/dto/QuizResponse.java
@@ -1,0 +1,27 @@
+package com.grow.notification_service.analysis.presentation.controller.dto;
+
+import java.util.List;
+
+import com.grow.notification_service.quiz.domain.model.Quiz;
+
+public record QuizResponse(
+	Long quizId,
+	String question,
+	List<String> choices,
+	String answer,
+	String explain,
+	String level,
+	Long categoryId
+) {
+	public static QuizResponse from(Quiz q) {
+		return new QuizResponse(
+			q.getQuizId(),
+			q.getQuestion(),
+			q.getChoices(),
+			q.getAnswer(),
+			q.getExplain(),
+			q.getLevel().name(),
+			q.getCategoryId()
+		);
+	}
+}

--- a/src/main/java/com/grow/notification_service/global/exception/ErrorCode.java
+++ b/src/main/java/com/grow/notification_service/global/exception/ErrorCode.java
@@ -39,7 +39,11 @@ public enum ErrorCode {
 	ANALYSIS_FOCUS_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500-5", "analysis.focus.parse.failed"),
 	ANALYSIS_FUTURE_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500-6", "analysis.future.parse.failed"),
 	ANALYSIS_OUTPUT_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500-7", "analysis.output.serialize.failed"),
-	ANALYSIS_LLM_CALL_FAILED(HttpStatus.BAD_GATEWAY, "502-0", "analysis.llm.call.failed"),;
+	ANALYSIS_LLM_CALL_FAILED(HttpStatus.BAD_GATEWAY, "502-0", "analysis.llm.call.failed"),
+	ANALYSIS_QUIZ_GENERATION_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500-8", "analysis.quiz.generation.parse.failed"),
+	ANALYSIS_REQUIRED_FIELD_MISSING(HttpStatus.INTERNAL_SERVER_ERROR, "500-9", "analysis.required.field.missing"),
+	ANALYSIS_INVALID_FIELD_VALUE(HttpStatus.INTERNAL_SERVER_ERROR, "500-10", "analysis.invalid.field.value"),
+	ANALYSIS_UNEXPECTED_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "500-11", "analysis.unexpected.failed"),;
 
 	private final HttpStatus status;
 	private final String code;

--- a/src/main/java/com/grow/notification_service/quiz/application/mapping/SkillTagToCategoryRegistry.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/mapping/SkillTagToCategoryRegistry.java
@@ -1,6 +1,7 @@
 package com.grow.notification_service.quiz.application.mapping;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -8,7 +9,7 @@ import com.grow.notification_service.global.exception.ErrorCode;
 import com.grow.notification_service.global.exception.QuizException;
 
 /**
- * 외부(Study.Group.SkillTag 코드) -> 내부(quiz.categoryId) 매핑.
+ * 외부(Study.Group.SkillTag 코드) <-> 내부(quiz.categoryId) 매핑.
  */
 @Component
 public class SkillTagToCategoryRegistry {
@@ -21,11 +22,25 @@ public class SkillTagToCategoryRegistry {
 		// 필요시 추가
 	);
 
+	// 매핑: quiz.categoryId -> SkillTag.name()
+	private static final Map<Long, String> REVERSE =
+		MAP.entrySet().stream()
+			.collect(Collectors.toUnmodifiableMap(
+				Map.Entry::getValue, // categoryId
+				Map.Entry::getKey    // skillTagCode
+			));
+
+	/** 외부 SkillTag -> 내부 categoryId */
 	public Long resolveOrThrow(String skillTagCode) {
 		Long id = MAP.get(skillTagCode);
-		if (id == null) {
-			throw new QuizException(ErrorCode.INVALID_SKILL_TAG);
-		}
+		if (id == null) throw new QuizException(ErrorCode.INVALID_SKILL_TAG);
 		return id;
+	}
+
+	/** 내부 categoryId -> 외부 SkillTag */
+	public String toSkillTagOrThrow(Long categoryId) {
+		String code = REVERSE.get(categoryId);
+		if (code == null) throw new QuizException(ErrorCode.CATEGORY_MISMATCH);
+		return code;
 	}
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -26,3 +26,7 @@ analysis.focus.parse.failed=핵심 개념(focusConcepts) 결과 파싱 중 오�
 analysis.future.parse.failed=확장 키워드(futureConcepts) 결과 파싱 중 오류가 발생했습니다.
 analysis.output.serialize.failed=분석 결과 직렬화 중 오류가 발생했습니다.
 analysis.llm.call.failed=LLM 호출 중 오류가 발생했습니다.
+analysis.quiz.generation.parse.failed=퀴즈 생성 결과 파싱 중 오류가 발생했습니다.
+analysis.required.field.missing=분석에 필요한 필드가 누락되었습니다.
+analysis.invalid.field.value=분석에 유효하지 않은 필드 값이 포함되어 있습니다.
+analysis.unexpected.failed=예기치 못한 오류가 발생했습니다.


### PR DESCRIPTION
## 🔍 Title(필수)
#42 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
### 카테고리 지정 퀴즈 생성 (5문제)
<img width="2175" height="1303" alt="스크린샷 2025-09-17 221253" src="https://github.com/user-attachments/assets/93c3248a-31d8-4bbe-8dc3-551021f59836" />

### 카테고리 지정 퀴즈 생성 (5문제, 토픽: 컴퓨터 공학 관련 회화)
<img width="2134" height="1274" alt="image" src="https://github.com/user-attachments/assets/dbd877d0-787d-40cb-8ccd-77bf20378a2a" />

### 틀린 문제 기반 퀴즈 생성 (5문제)
<img width="2179" height="1293" alt="스크린샷 2025-09-17 221243" src="https://github.com/user-attachments/assets/b3e5fd7b-1173-4390-89f4-25f159965660" />


### DB 및 로그
<img width="2267" height="221" alt="스크린샷 2025-09-17 221311" src="https://github.com/user-attachments/assets/d8bafcb8-47d7-4933-afdb-85d6ad7bf170" />

<img width="1558" height="184" alt="image" src="https://github.com/user-attachments/assets/f0df7596-67ec-4a31-b844-1d7147135872" />

## 🔗 Related Issues(필수)
Closes #42

## 📝 Note (주의 사항)
두 가지 기능 구현했습니다
### 1) 카테고리/토픽 기반 문제 생성

카테고리/토픽을 고른다 -> 생성 요청 -> 5문제가 한 세트로 나온다 -> 해설까지 빠르게 확인 -> 저장

- 적용 조건
    - 항상 5문제로 딱 맞게 생성
    - 보기는 4개
    - 정답은 보기 중 하나와 글자까지 완전히 동일해야 함
    - 난이도
        - RANDOM이면 EASY/NORMAL/HARD가 섞여서 출제
        - 특정 난이도를 지정하면 모든 문제에 동일 난이도 적용
    - 카테고리/토픽 범위를 벗어나지 않음(선택한 주제 안에서만 문제 구성)
    - 해설은 1~2문장으로 짧고 핵심만

### 2) 오답(틀린 문제) 기반 문제 생성

내 오답을 모은다 -> 비슷하지만 다른 문제로 새 세트를 만든다 -> 중복된 문제는 자동 제외 -> 저장

- 적용 조건
    - 내가 틀렸던 개념을 가져와서, 같은 영역을 다시 익히되 그대로 똑같은 문제를 반복하지 않도록 출제
    - 결과는 마찬가지로 항상 5문제, 보기는 4개, 정답은 보기 중 하나와 완전 일치
    - 난이도 규칙은 위와 동일
    - 카테고리 일치: 오답 중에서도 현재 카테고리에 해당하는 문제들만 반영
    - 세트 내부 중복 제거: 생성된 5문제 중 질문이 동일하면 자동 제외 
    - 기존 DB 중복 제거: 이미 있던 질문이면 저장 대상에서 제외 (생성 시 마다 달라지니 얼마나 걸러질까 싶어요..)
    - 해설은 1~2문장으로 제공
    

깨지지 않고 잘 나오긴 하는데 40~50초 정도 걸리고.. 제미나이에서 503 에러가 자주 뜨더라구요(과부하) 이거 관련해서 리트라이 로직 만들겟습니다.. 분명 내부 리트라이가 잇다고 햇엇는데.. 뭐지..