### PR TITLE
✨ feat: AI 요청 이벤트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,9 @@ dependencies {
 
 	// 제미나이 AI
 	implementation "com.google.genai:google-genai:1.16.0"
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/notification_service/analysis/application/service/AiReviewQueryService.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/AiReviewQueryService.java
@@ -1,0 +1,9 @@
+package com.grow.notification_service.analysis.application.service;
+
+import java.util.List;
+
+import com.grow.notification_service.quiz.application.dto.QuizItem;
+
+public interface AiReviewQueryService {
+	List<QuizItem> getLatestGenerated(Long memberId, Long categoryId, Integer sizeOpt);
+}

--- a/src/main/java/com/grow/notification_service/analysis/application/service/impl/AiReviewQueryServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/impl/AiReviewQueryServiceImpl.java
@@ -1,0 +1,86 @@
+package com.grow.notification_service.analysis.application.service.impl;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grow.notification_service.analysis.application.service.AiReviewQueryService;
+import com.grow.notification_service.analysis.infra.persistence.entity.MemberLatestAiReviewId;
+import com.grow.notification_service.analysis.infra.persistence.repository.MemberLatestAiReviewJpaRepository;
+import com.grow.notification_service.quiz.application.dto.QuizItem;
+import com.grow.notification_service.quiz.domain.model.Quiz;
+import com.grow.notification_service.quiz.domain.repository.QuizRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiReviewQueryServiceImpl implements AiReviewQueryService {
+
+	private final MemberLatestAiReviewJpaRepository latestRepo;
+	private final QuizRepository quizRepository;
+	private final ObjectMapper mapper;
+
+	/**
+	 * 멤버별, 카테고리별 최신 AI 복습 퀴즈 목록 조회
+	 * @param memberId 멤버 ID
+	 * @param categoryId 카테고리 ID
+	 * @param sizeOpt 최대 개수 (null 또는 0 이하일 경우 기본값 5)
+	 * @return 퀴즈 목록 (없을 경우 빈 리스트)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<QuizItem> getLatestGenerated(Long memberId, Long categoryId, Integer sizeOpt) {
+		MemberLatestAiReviewId id = new MemberLatestAiReviewId(memberId, categoryId);
+
+		return latestRepo.findById(id)
+			.map(row -> {
+				List<Long> ids = parseIds(row.getQuizIdsJson());
+				if (ids.isEmpty()) {
+					return Collections.<QuizItem>emptyList();
+				}
+
+				// 요청된 개수 또는 기본값
+				int requested = (sizeOpt == null || sizeOpt <= 0) ? 5 : sizeOpt;
+				int size = Math.min(requested, ids.size());
+
+				// 최신 퀴즈 ID 기준으로 자르기
+				List<Long> clipped = (ids.size() > size)
+					? ids.subList(ids.size() - size, ids.size())
+					: ids;
+
+				List<Quiz> quizzes = quizRepository.findByIds(clipped);
+
+				Map<Long, Quiz> byId = quizzes.stream()
+					.collect(Collectors.toMap(Quiz::getQuizId, q -> q, (a, b) -> a));
+
+				// clipped 순서를 유지하여 DTO 변환
+				return clipped.stream()
+					.map(byId::get)
+					.filter(Objects::nonNull)
+					.map(QuizItem::from)
+					.collect(Collectors.toList());
+			})
+			.orElseGet(Collections::<QuizItem>emptyList);
+	}
+
+	/**
+	 * 퀴즈 ID 리스트 JSON 파싱
+	 * @param json 퀴즈 ID 리스트 JSON
+	 * @return 파싱된 퀴즈 ID 리스트 (실패 시 빈 리스트)
+	 */
+	private List<Long> parseIds(String json) {
+		try {
+			return mapper.readValue(json, new TypeReference<List<Long>>() {});
+		} catch (Exception e) {
+			log.warn("[AI-REVIEW][QUERY] quizIdsJson 파싱 실패: {}", json, e);
+			return Collections.emptyList();
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/analysis/application/service/impl/AnalysisApplicationServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/impl/AnalysisApplicationServiceImpl.java
@@ -9,7 +9,7 @@ import com.grow.notification_service.analysis.domain.model.Analysis;
 import com.grow.notification_service.analysis.domain.repository.AnalysisRepository;
 import com.grow.notification_service.global.exception.AnalysisException;
 import com.grow.notification_service.global.exception.ErrorCode;
-import com.grow.notification_service.quiz.application.MemberQuizResultPort;
+import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.quiz.domain.model.Quiz;
 import com.grow.notification_service.quiz.domain.repository.QuizRepository;
 import com.grow.notification_service.analysis.domain.model.KeywordConcept;

--- a/src/main/java/com/grow/notification_service/analysis/application/service/impl/QuizGenerationApplicationServiceImpl.java
+++ b/src/main/java/com/grow/notification_service/analysis/application/service/impl/QuizGenerationApplicationServiceImpl.java
@@ -19,7 +19,7 @@ import com.grow.notification_service.analysis.application.prompt.QuizPrompt;
 import com.grow.notification_service.analysis.application.service.QuizGenerationApplicationService;
 import com.grow.notification_service.global.exception.AnalysisException;
 import com.grow.notification_service.global.exception.ErrorCode;
-import com.grow.notification_service.quiz.application.MemberQuizResultPort;
+import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.quiz.application.mapping.SkillTagToCategoryRegistry;
 import com.grow.notification_service.quiz.domain.model.Quiz;
 import com.grow.notification_service.quiz.domain.repository.QuizRepository;

--- a/src/main/java/com/grow/notification_service/analysis/infra/kafka/AiReviewConsumer.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/kafka/AiReviewConsumer.java
@@ -1,0 +1,99 @@
+package com.grow.notification_service.analysis.infra.kafka;
+
+import java.time.Duration;
+import java.util.List;
+
+import com.grow.notification_service.global.util.JsonUtils;
+import com.grow.notification_service.analysis.application.service.QuizGenerationApplicationService;
+import com.grow.notification_service.quiz.application.event.AiReviewRequestedEvent;
+import com.grow.notification_service.quiz.application.port.SubscriptionPort;
+import com.grow.notification_service.quiz.domain.model.Quiz;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiReviewConsumer {
+
+	private final SubscriptionPort subscriptionPort;
+	private final QuizGenerationApplicationService quizGen;
+	private final StringRedisTemplate redis;
+
+	private static final Duration DEDUPE_TTL = Duration.ofMinutes(10); // 10분 내 중복 요청 차단
+
+	/**
+	 * AI 복습 퀴즈 생성 요청 수신
+	 * @param payload JSON 페이로드
+	 */
+	@KafkaListener(
+		topics = "member.ai-review.requested",
+		groupId = "ai-review",
+		concurrency = "3"
+	)
+	@RetryableTopic(
+		attempts = "${kafka.retry.worker.attempts:5}",
+		backoff = @Backoff(delay = 1000, multiplier = 2),
+		dltTopicSuffix = ".dlt",
+		autoCreateTopics = "true"
+	)
+	public void onMessage(@Payload String payload) {
+		try {
+			AiReviewRequestedEvent evt = JsonUtils.fromJsonString(payload, AiReviewRequestedEvent.class);
+
+			// 구독 확인
+			if (!subscriptionPort.canGenerateAiReview(evt.memberId())) {
+				log.info("[AI-REVIEW][BLOCKED] 구독 비활성 - memberId={}, categoryId={}", evt.memberId(), evt.categoryId());
+				return;
+			}
+
+			// 중복 방지
+			String key = (evt.dedupeKey() != null && !evt.dedupeKey().isBlank())
+				? evt.dedupeKey()
+				: "ai-review:req:%d:%d".formatted(evt.memberId(), evt.categoryId());
+
+			// 키가 이미 존재하면 중복으로 간주하고 스킵
+			if (!tryAcquireDedupe(key, DEDUPE_TTL)) {
+				log.info("[AI-REVIEW][SKIP] 중복 스킵 - {}", key);
+				return;
+			}
+
+			// 복습 퀴즈 생성
+			List<Quiz> saved = quizGen.generateQuizzesFromWrong(
+				evt.memberId(), evt.categoryId(), evt.levelParam(), evt.topic()
+			);
+			log.info("[AI-REVIEW][GEN][END] memberId={}, categoryId={}, saved={}",
+				evt.memberId(), evt.categoryId(), saved.size());
+
+		} catch (Exception e) {
+			log.error("[KAFKA][AI-REVIEW-WORKER][ERROR] payload={}", payload, e);
+			throw e;
+		}
+	}
+
+	// 헬퍼
+
+	/**
+	 * 중복 요청 방지용
+	 * @param key 중복 방지 키
+	 * @param ttl 만료 시간
+	 * @return 획득 성공 여부
+	 */
+	private boolean tryAcquireDedupe(String key, Duration ttl) {
+		try {
+			Boolean ok = redis.opsForValue().setIfAbsent(key, "1", ttl);
+			return Boolean.TRUE.equals(ok);
+		} catch (Exception e) {
+			log.warn("[AI-REVIEW][DEDUPE][FAIL] key={}", key, e);
+			return false;
+		}
+	}
+}

--- a/src/main/java/com/grow/notification_service/analysis/infra/kafka/AiReviewRequestedDltConsumer.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/kafka/AiReviewRequestedDltConsumer.java
@@ -1,0 +1,47 @@
+package com.grow.notification_service.analysis.infra.kafka;
+
+import com.grow.notification_service.global.slack.SlackErrorSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+/**
+ * AI 리뷰 요청 이벤트가 재시도 끝에 실패(DLT 도착)했을 때 처리하는 Consumer
+ * - 로그 및 슬랙 알림 전송
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiReviewRequestedDltConsumer {
+
+	private final SlackErrorSendService slackErrorSendService;
+
+	@KafkaListener(
+		topics = "member.ai-review.requested.dlt",
+		groupId = "ai-review-dlt"
+	)
+	public void consumeDlt(
+		String message,
+		@Header(value = KafkaHeaders.RECEIVED_TOPIC, required = false) String topic,
+		@Header(value = KafkaHeaders.OFFSET, required = false) Long offset,
+		@Header(value = KafkaHeaders.RECEIVED_TIMESTAMP, required = false) Long timestamp
+	) {
+		String safeMsg = message == null ? "" : message.trim();
+		log.error("[AI-REVIEW DLT] topic={} partition={} offset={} ts={} payload={}",
+			topic, offset, timestamp, safeMsg);
+
+		slackErrorSendService.sendError(
+			"AI 복습 퀴즈 생성 - 처리 실패",
+			"카테고리: [AI-REVIEW]\n"
+				+ "상세: AI 복습 퀴즈 생성 요청이 재시도 끝에 실패하여 DLT로 이동했습니다.\n"
+				+ "메타: topic=%s, offset=%s, timestamp=%s"
+				.formatted(topic, String.valueOf(offset), String.valueOf(timestamp)),
+			safeMsg
+		);
+
+		log.info("[AI-REVIEW DLT] 처리 완료");
+	}
+}

--- a/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewId.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewId.java
@@ -1,0 +1,19 @@
+package com.grow.notification_service.analysis.infra.persistence.entity;
+
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MemberLatestAiReviewId implements Serializable {
+	private Long memberId;
+	private Long categoryId;
+}

--- a/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewId.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewId.java
@@ -6,10 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewJpaEntity.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewJpaEntity.java
@@ -1,0 +1,39 @@
+package com.grow.notification_service.analysis.infra.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 회원별 최신 AI 리뷰 기록 엔티티
+ */
+@Entity
+@Table(name = "member_latest_ai_review")
+@IdClass(MemberLatestAiReviewId.class)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLatestAiReviewJpaEntity {
+
+	@Id
+	@Column(nullable = false)
+	private Long memberId;
+
+	@Id
+	@Column(nullable = false)
+	private Long categoryId;
+
+	@Lob
+	@Column(nullable = false)
+	private String quizIdsJson;
+
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewJpaEntity.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/persistence/entity/MemberLatestAiReviewJpaEntity.java
@@ -7,19 +7,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 /**
  * 회원별 최신 AI 리뷰 기록 엔티티
  */
 @Entity
-@Table(name = "member_latest_ai_review")
-@IdClass(MemberLatestAiReviewId.class)
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@IdClass(MemberLatestAiReviewId.class)
+@Table(name = "member_latest_ai_review")
 public class MemberLatestAiReviewJpaEntity {
 
 	@Id

--- a/src/main/java/com/grow/notification_service/analysis/infra/persistence/repository/MemberLatestAiReviewJpaRepository.java
+++ b/src/main/java/com/grow/notification_service/analysis/infra/persistence/repository/MemberLatestAiReviewJpaRepository.java
@@ -1,0 +1,9 @@
+package com.grow.notification_service.analysis.infra.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.grow.notification_service.analysis.infra.persistence.entity.MemberLatestAiReviewId;
+import com.grow.notification_service.analysis.infra.persistence.entity.MemberLatestAiReviewJpaEntity;
+
+public interface MemberLatestAiReviewJpaRepository
+	extends JpaRepository<MemberLatestAiReviewJpaEntity, MemberLatestAiReviewId> {}

--- a/src/main/java/com/grow/notification_service/analysis/presentation/controller/AnalysisController.java
+++ b/src/main/java/com/grow/notification_service/analysis/presentation/controller/AnalysisController.java
@@ -2,6 +2,8 @@ package com.grow.notification_service.analysis.presentation.controller;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,11 +11,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grow.notification_service.analysis.application.service.AiReviewQueryService;
 import com.grow.notification_service.analysis.application.service.AnalysisApplicationService;
 import com.grow.notification_service.analysis.application.service.QuizGenerationApplicationService;
 import com.grow.notification_service.analysis.domain.model.Analysis;
 import com.grow.notification_service.analysis.presentation.controller.dto.AnalysisResponse;
 import com.grow.notification_service.analysis.presentation.controller.dto.QuizResponse;
+import com.grow.notification_service.global.dto.RsData;
+import com.grow.notification_service.quiz.application.dto.QuizItem;
 import com.grow.notification_service.quiz.domain.model.Quiz;
 
 import lombok.RequiredArgsConstructor;
@@ -26,6 +31,7 @@ public class AnalysisController {
 	private final AnalysisApplicationService service;
 	private final QuizGenerationApplicationService quizService;
 	private final ObjectMapper objectMapper;
+	private final AiReviewQueryService aiReviewQueryService;
 
 	/**
 	 * 자바 프로그래밍 학습 로드맵 분석 요청 (테스트용입니다)
@@ -78,5 +84,16 @@ public class AnalysisController {
 	) {
 		List<Quiz> created = quizService.generateQuizzesFromWrong(memberId, categoryId, level, topic);
 		return created.stream().map(QuizResponse::from).toList();
+	}
+
+	/** 최근 생성된 AI 복습 퀴즈 조회 */
+	@GetMapping("/latest")
+	public ResponseEntity<RsData<List<QuizItem>>> getLatest(
+		@RequestHeader("X-Authorization-Id") Long memberId,
+		@RequestParam("categoryId") Long categoryId,
+		@RequestParam(value = "size", required = false) Integer size
+	) {
+		List<QuizItem> items = aiReviewQueryService.getLatestGenerated(memberId, categoryId, size);
+		return ResponseEntity.ok(new RsData<>("200", "AI 복습 퀴즈 조회 성공", items));
 	}
 }

--- a/src/main/java/com/grow/notification_service/quiz/application/event/AiReviewRequestedEvent.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/event/AiReviewRequestedEvent.java
@@ -1,0 +1,12 @@
+package com.grow.notification_service.quiz.application.event;
+
+import java.time.LocalDateTime;
+
+public record AiReviewRequestedEvent(
+	Long memberId,
+	Long categoryId,
+	String levelParam,
+	String topic,
+	String dedupeKey,
+	LocalDateTime requestedAt
+) {}

--- a/src/main/java/com/grow/notification_service/quiz/application/event/AiReviewRequestedProducer.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/event/AiReviewRequestedProducer.java
@@ -1,0 +1,44 @@
+package com.grow.notification_service.quiz.application.event;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.grow.notification_service.global.util.JsonUtils;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * AI 리뷰 요청 이벤트 발행자
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiReviewRequestedProducer {
+	private static final String TOPIC = "member.ai-review.requested";
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final Clock clock;
+
+	/**
+	 * AI 리뷰 요청 이벤트 발행
+	 * @param memberId 멤버 ID
+	 * @param categoryId 카테고리 ID
+	 * @param levelParam 레벨 파라미터
+	 * @param topic 주제
+	 * @param dedupeKey 중복 방지 키
+	 */
+	public void publish(Long memberId, Long categoryId, String levelParam, String topic, String dedupeKey) {
+		LocalDateTime now = LocalDateTime.now(clock);
+		AiReviewRequestedEvent event = new AiReviewRequestedEvent(
+			memberId, categoryId, levelParam, topic, dedupeKey, now
+		);
+		String key = String.valueOf(memberId);
+		kafkaTemplate.send(TOPIC, key, JsonUtils.toJsonString(event));
+		log.info("[KAFKA][SENT] topic={} key={} memberId={} categoryId={} dedupeKey={}",
+			TOPIC, key, memberId, categoryId, dedupeKey);
+	}
+}

--- a/src/main/java/com/grow/notification_service/quiz/application/port/MemberQuizResultPort.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/port/MemberQuizResultPort.java
@@ -1,4 +1,4 @@
-package com.grow.notification_service.quiz.application;
+package com.grow.notification_service.quiz.application.port;
 
 import java.util.List;
 

--- a/src/main/java/com/grow/notification_service/quiz/application/port/SubscriptionPort.java
+++ b/src/main/java/com/grow/notification_service/quiz/application/port/SubscriptionPort.java
@@ -1,0 +1,6 @@
+package com.grow.notification_service.quiz.application.port;
+
+public interface SubscriptionPort {
+	/** 현재 시점에 AI 복습 퀴즈 생성 가능(유효 구독) 여부 */
+	boolean canGenerateAiReview(Long memberId);
+}

--- a/src/main/java/com/grow/notification_service/quiz/infra/client/MemberQuizResultWebClientAdapter.java
+++ b/src/main/java/com/grow/notification_service/quiz/infra/client/MemberQuizResultWebClientAdapter.java
@@ -1,6 +1,6 @@
 package com.grow.notification_service.quiz.infra.client;
 
-import com.grow.notification_service.quiz.application.MemberQuizResultPort;
+import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.global.exception.ErrorCode;
 import com.grow.notification_service.global.exception.QuizException;
 

--- a/src/main/java/com/grow/notification_service/quiz/infra/client/PaymentSubscriptionWebClientAdapter.java
+++ b/src/main/java/com/grow/notification_service/quiz/infra/client/PaymentSubscriptionWebClientAdapter.java
@@ -1,0 +1,70 @@
+package com.grow.notification_service.quiz.infra.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.grow.notification_service.global.exception.ErrorCode;
+import com.grow.notification_service.global.exception.QuizException;
+import com.grow.notification_service.quiz.application.port.SubscriptionPort;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentSubscriptionWebClientAdapter implements SubscriptionPort {
+
+	private final WebClient webClient;
+
+	@Value("${services.payment.base-url}")
+	private String paymentServiceBaseUrl;
+
+	@Value("${payment.subscription.ai-review.path:/api/v1/payment/internal/subscriptions/ai-review}")
+	private String aiReviewPath;
+
+	private WebClient paymentClient;
+
+	@PostConstruct
+	void init() {
+		this.paymentClient = webClient.mutate()
+			.baseUrl(paymentServiceBaseUrl)
+			.build();
+	}
+
+	@Override
+	public boolean canGenerateAiReview(Long memberId) {
+		RsData<AiReviewSubscriptionResponse> rs = paymentClient.get()
+			.uri(aiReviewPath)
+			.header("X-Authorization-Id", String.valueOf(memberId))
+			.retrieve()
+			.onStatus(HttpStatusCode::isError, resp ->
+				resp.bodyToMono(String.class)
+					.defaultIfEmpty("")
+					.flatMap(body -> {
+						int sc = resp.statusCode().value();
+						log.warn("[SUBSCRIPTION][HTTP_ERROR] status={}, body={}", sc, body);
+						return reactor.core.publisher.Mono.error(
+							new QuizException(ErrorCode.MEMBER_RESULT_FETCH_FAILED, new RuntimeException(body))
+						);
+					})
+			)
+			.bodyToMono(new ParameterizedTypeReference<RsData<AiReviewSubscriptionResponse>>() {})
+			.block();
+
+		if (rs == null || rs.data == null) {
+			throw new QuizException(ErrorCode.MEMBER_RESULT_FETCH_FAILED);
+		}
+		return rs.data.aiReviewAllowed();
+	}
+
+	/** payment_service가 RsData로 내려주는 페이로드 DTO */
+	public record AiReviewSubscriptionResponse(Long memberId, boolean aiReviewAllowed) {}
+
+	/** WebClient 응답 래퍼 (프로젝트 컨벤션) */
+	public record RsData<T>(String code, String message, T data) {}
+}

--- a/src/test/java/com/grow/notification_service/quiz/application/service/impl/QuizApplicationServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/quiz/application/service/impl/QuizApplicationServiceImplTest.java
@@ -2,7 +2,7 @@ package com.grow.notification_service.quiz.application.service.impl;
 
 import com.grow.notification_service.global.exception.ErrorCode;
 import com.grow.notification_service.global.exception.QuizException;
-import com.grow.notification_service.quiz.application.MemberQuizResultPort;
+import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.quiz.application.dto.QuizItem;
 import com.grow.notification_service.quiz.application.event.QuizAnsweredProducer;
 import com.grow.notification_service.quiz.application.mapping.SkillTagToCategoryRegistry;

--- a/src/test/java/com/grow/notification_service/quiz/application/service/impl/QuizApplicationServiceImplTest.java
+++ b/src/test/java/com/grow/notification_service/quiz/application/service/impl/QuizApplicationServiceImplTest.java
@@ -2,10 +2,11 @@ package com.grow.notification_service.quiz.application.service.impl;
 
 import com.grow.notification_service.global.exception.ErrorCode;
 import com.grow.notification_service.global.exception.QuizException;
-import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.quiz.application.dto.QuizItem;
+import com.grow.notification_service.quiz.application.event.AiReviewRequestedProducer;
 import com.grow.notification_service.quiz.application.event.QuizAnsweredProducer;
 import com.grow.notification_service.quiz.application.mapping.SkillTagToCategoryRegistry;
+import com.grow.notification_service.quiz.application.port.MemberQuizResultPort;
 import com.grow.notification_service.quiz.application.service.QuizApplicationService;
 import com.grow.notification_service.quiz.domain.model.Quiz;
 import com.grow.notification_service.quiz.domain.repository.QuizRepository;
@@ -13,12 +14,11 @@ import com.grow.notification_service.quiz.infra.persistence.enums.QuizLevel;
 import com.grow.notification_service.quiz.presentation.dto.SubmitAnswerItem;
 import com.grow.notification_service.quiz.presentation.dto.SubmitAnswersRequest;
 import com.grow.notification_service.quiz.presentation.dto.SubmitAnswersResponse;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 
@@ -37,15 +37,23 @@ class QuizApplicationServiceImplTest {
 	@Mock private MemberQuizResultPort memberResultPort;
 	@Mock private QuizRepository quizRepository;
 	@Mock private QuizAnsweredProducer eventPublisher;
+	@Mock private AiReviewRequestedProducer aiReviewRequestedProducer;
 
 	private QuizApplicationService service;
 
 	@BeforeEach
 	void setUp() {
-		service = new QuizApplicationServiceImpl(registry, memberResultPort, quizRepository, eventPublisher);
+		service = new QuizApplicationServiceImpl(
+			registry,
+			memberResultPort,
+			quizRepository,
+			eventPublisher,
+			aiReviewRequestedProducer
+		);
 	}
 
 	private Quiz makeQuiz(Long id, Long categoryId, QuizLevel level, String answer) {
+		// 선택지는 4개가 일반적이지만, 도메인 제약이 없다면 3개여도 테스트엔 문제 없음.
 		return new Quiz(
 			id,
 			"Q" + id,
@@ -127,7 +135,7 @@ class QuizApplicationServiceImplTest {
 	class SubmitAnswers {
 
 		@Test
-		@DisplayName("정상: 2개 제출, 1개 정답 → 이벤트 2건 발행")
+		@DisplayName("정상: 2개 제출, 1개 정답 → 정답/오답 이벤트 2건 + AI 리뷰 요청 1건")
 		void success_submit_two_items() {
 			Long memberId = 77L;
 			String skillTag = "JAVA_PROGRAMMING";
@@ -148,8 +156,13 @@ class QuizApplicationServiceImplTest {
 			assertEquals(1, resp.correctCount());
 			assertEquals(2, resp.results().size());
 
+			// 퀴즈 정답 제출 이벤트(문항별) 2건
 			verify(eventPublisher, times(2))
 				.publish(eq(memberId), anyLong(), eq(10L), anyString(), anyString(), anyBoolean());
+
+			// 오답이 하나라도 있었으므로 AI 리뷰 요청 1건
+			verify(aiReviewRequestedProducer, times(1))
+				.publish(eq(memberId), eq(10L), eq("NORMAL"), isNull(), isNull());
 		}
 
 		@Test
@@ -160,7 +173,9 @@ class QuizApplicationServiceImplTest {
 			SubmitAnswersRequest req = new SubmitAnswersRequest("NOPE", "EASY",
 				List.of(new SubmitAnswerItem(1L, "A")));
 			assertThrows(QuizException.class, () -> service.submitAnswers(1L, req));
+
 			verify(eventPublisher, never()).publish(anyLong(), anyLong(), anyLong(), anyString(), anyString(), anyBoolean());
+			verify(aiReviewRequestedProducer, never()).publish(anyLong(), anyLong(), anyString(), any(), any());
 		}
 
 		@Test
@@ -173,7 +188,9 @@ class QuizApplicationServiceImplTest {
 				List.of(new SubmitAnswerItem(999L, "A")));
 
 			assertThrows(QuizException.class, () -> service.submitAnswers(1L, req));
+
 			verify(eventPublisher, never()).publish(anyLong(), anyLong(), anyLong(), anyString(), anyString(), anyBoolean());
+			verify(aiReviewRequestedProducer, never()).publish(anyLong(), anyLong(), anyString(), any(), any());
 		}
 
 		@Test
@@ -187,11 +204,13 @@ class QuizApplicationServiceImplTest {
 				List.of(new SubmitAnswerItem(1L, "A")));
 
 			assertThrows(QuizException.class, () -> service.submitAnswers(1L, req));
+
 			verify(eventPublisher, never()).publish(anyLong(), anyLong(), anyLong(), anyString(), anyString(), anyBoolean());
+			verify(aiReviewRequestedProducer, never()).publish(anyLong(), anyLong(), anyString(), any(), any());
 		}
 
 		@Test
-		@DisplayName("정상: 모두 오답이어도 이벤트는 발행된다")
+		@DisplayName("정상: 모두 오답이어도 이벤트는 2건 + AI 리뷰 요청 1건")
 		void success_all_wrong_still_publish_events() {
 			when(registry.resolveOrThrow("JAVA_PROGRAMMING")).thenReturn(10L);
 			Quiz q1 = makeQuiz(1L, 10L, QuizLevel.EASY, "A");
@@ -206,8 +225,13 @@ class QuizApplicationServiceImplTest {
 
 			assertEquals(2, resp.total());
 			assertEquals(0, resp.correctCount());
+
 			verify(eventPublisher, times(2))
 				.publish(eq(123L), anyLong(), eq(10L), anyString(), anyString(), eq(false));
+
+			// 오답 포함 → AI 리뷰 요청은 1회
+			verify(aiReviewRequestedProducer, times(1))
+				.publish(eq(123L), eq(10L), eq("EASY"), isNull(), isNull());
 		}
 	}
 
@@ -229,7 +253,7 @@ class QuizApplicationServiceImplTest {
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, false)).thenReturn(wrongIds);
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, true)).thenReturn(correctIds);
 
-			// historyInCategory (unionIds = 7개) 정확 매칭
+			// historyInCategory (unionIds = 7개)
 			List<Long> unionIds = List.of(1L,2L,3L,4L,5L,6L,7L);
 			List<Quiz> historyQuizzes = unionIds.stream()
 				.map(id -> makeQuiz(id, categoryId, QuizLevel.EASY, "A"))
@@ -241,7 +265,7 @@ class QuizApplicationServiceImplTest {
 				any(PageRequest.class))
 			).thenReturn(historyQuizzes);
 
-			// 1) wrong 3개 (wrongIds 정확 매칭)
+			// 1) wrong 3개
 			List<Quiz> fromWrong = List.of(
 				makeQuiz(1L, categoryId, QuizLevel.EASY, "A"),
 				makeQuiz(2L, categoryId, QuizLevel.EASY, "A"),
@@ -254,7 +278,7 @@ class QuizApplicationServiceImplTest {
 				any(PageRequest.class))
 			).thenReturn(fromWrong);
 
-			// 2) correct 2개 (correctIds 풀만 매칭되도록 사이즈 조건 추가)
+			// 2) correct 2개
 			List<Quiz> fromCorrect = List.of(
 				makeQuiz(5L, categoryId, QuizLevel.NORMAL, "B"),
 				makeQuiz(6L, categoryId, QuizLevel.NORMAL, "B")
@@ -287,7 +311,7 @@ class QuizApplicationServiceImplTest {
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, false)).thenReturn(List.of(1L, 2L));
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, true)).thenReturn(List.of(3L, 4L));
 
-			// historyInCategory 결과도 4개로 귀결되도록 stub
+			// historyInCategory 4개로 세팅
 			List<Long> unionIds = List.of(1L,2L,3L,4L);
 			List<Quiz> historyQuizzes = unionIds.stream()
 				.map(id -> makeQuiz(id, categoryId, QuizLevel.EASY, "A"))
@@ -311,13 +335,12 @@ class QuizApplicationServiceImplTest {
 
 			when(registry.resolveOrThrow(skillTag)).thenReturn(categoryId);
 
-			// 틀린 1개, 맞은 5개 → unionIds = 6개 >= 5 (최소 이력 충족)
+			// 틀린 1개, 맞은 5개 → unionIds = 6개 (최소 이력 충족)
 			List<Long> wrongIds = List.of(1L);
 			List<Long> correctIds = List.of(9L, 10L, 11L, 12L, 13L);
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, false)).thenReturn(wrongIds);
 			when(memberResultPort.findAnsweredQuizIds(memberId, categoryId, true)).thenReturn(correctIds);
 
-			// historyInCategory는 unionIds 전체가 반환되도록 정확 매칭
 			List<Long> unionIds = new java.util.ArrayList<>();
 			unionIds.addAll(wrongIds);
 			unionIds.addAll(correctIds);
@@ -332,7 +355,7 @@ class QuizApplicationServiceImplTest {
 			).thenReturn(historyQuizzes);
 
 			// total=5, wrongRatio=0.6 → wrongNeed=3, correctNeed=2
-			// 1) 틀린에서 1개만 뽑힘(부족)
+			// 1) 틀린에서 1개만
 			List<Quiz> fromWrong = List.of(makeQuiz(1L, categoryId, QuizLevel.NORMAL, "C"));
 			when(quizRepository.pickFromIncludeIds(
 				eq(categoryId),
@@ -355,7 +378,7 @@ class QuizApplicationServiceImplTest {
 				any(PageRequest.class))
 			).thenReturn(fromCorrect);
 
-			// 3) 랜덤 보충 2개(총 5개 맞추기)
+			// 3) 랜덤 보충 2개
 			List<Quiz> fills = List.of(
 				makeQuiz(101L, categoryId, QuizLevel.EASY, "A"),
 				makeQuiz(102L, categoryId, QuizLevel.EASY, "A")
@@ -377,8 +400,6 @@ class QuizApplicationServiceImplTest {
 			);
 			verify(quizRepository).pickFillRandomExcluding(eq(categoryId), isNull(), anyList(), any(PageRequest.class));
 		}
-
-
 
 		@Test
 		@DisplayName("에러: 지원하지 않는 모드이면 QuizException (복습)")


### PR DESCRIPTION
## 🔍 Title(필수)
#44 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result

## 🔗 Related Issues(필수)
Closes #44

### 구독 비활성 상태일 시 문제 발행 x
<img width="1204" height="45" alt="스크린샷 2025-09-18 222010" src="https://github.com/user-attachments/assets/d3abca56-ba4f-4b9d-b830-1be061cef0ff" />

### 정답 제출 시 문제 발행 로그
<img width="1411" height="411" alt="스크린샷 2025-09-19 130800" src="https://github.com/user-attachments/assets/af95129c-fe41-4c3d-93af-744eff0e5823" />

### 최근 생성한 5문제
<img width="2175" height="1313" alt="스크린샷 2025-09-19 130812" src="https://github.com/user-attachments/assets/dc202bf1-99c3-40ca-a6c7-2aa8a0688c79" />
<img width="2132" height="106" alt="스크린샷 2025-09-19 130849" src="https://github.com/user-attachments/assets/31796768-6d94-494b-bc80-e25cdeccccea" />

### 생성한 문제 id 저장하는 db
<img width="528" height="132" alt="스크린샷 2025-09-19 130857" src="https://github.com/user-attachments/assets/efb72cde-2ada-4aef-8839-b803aae00a67" />



### 사진 더 추가 예정..
## 📝 Note (주의 사항)
정답 제출 시 이벤트 발행하게 수정했습니다. 
- 결제 서비스에 구독 상태 확인하는 내부 api 추가
- 정답 제출 시 카프카 이벤트(member.quiz.answered) 발행
- 컨슈머가 구독 상태(Subscription) 확인 후, 오답이 있는 제출에 한해 AI 복습 퀴즈 생성 요청 이벤트(member.ai-review.requested) 발행
- 컨슈머가 오답 이력 기반으로 LLM 호출 -> 신규 퀴즈 5개 생성 및 저장
- 최근 생성된 AI 복습 퀴즈를 조회하는 엔티티, 서비스, API 추가
  - 해당 문제의 id만 저장
todo
- ai 복습 퀴즈 조회 이벤트 만들어야 함.. 분석 뽑아주는 거
- 복습 문제 뽑아줄 때 문제의 평균 난이도를 받아서, 그 난이도 기준으로 뽑아줄 수 있게 수정해야 함
- 문제 다 만들어지면 알림 발송하게 이벤트 달아야 함
- 제미나이 503 오버로드 에러 뜰 때 리트라이 할 수 있게 만들어야 함
이 todo들 다 한 pr에 넣으면 아침부터 기분이 언짢아지실까 봐 일단 잘라서 올렷습니다!!!
할거준내많네요!!! 하루 안에 다 해볼게요!!!